### PR TITLE
v0.8.2

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -25,6 +25,10 @@ jobs:
         shell: pwsh
         run: |
           Install-Module -Name PScriboCharts -Repository PSGallery -Force
+      - name: Install Diagrammer.Core module
+        shell: pwsh
+        run: |
+          Install-Module -Name Diagrammer.Core -Repository PSGallery -Force
       - name: Install Diagrammer.Microsoft.AD module
         shell: pwsh
         run: |
@@ -41,7 +45,7 @@ jobs:
     needs: publish-to-gallery
     runs-on: ubuntu-latest
     steps:
-      - uses: Eomm/why-don-t-you-tweet@v1
+      - uses: Eomm/why-don-t-you-tweet@v2
         # We don't want to tweet if the repository is not a public one
         if: ${{ !github.event.repository.private }}
         with:

--- a/AsBuiltReport.Microsoft.AD.json
+++ b/AsBuiltReport.Microsoft.AD.json
@@ -21,9 +21,9 @@
     },
     "InfoLevel": {
         "_comment_": "0 = Disabled, 1 = Enabled, 2 = Adv Summary, 3 = Detailed",
-        "Forest": 1,
-        "Domain": 1,
-        "DNS": 0,
+        "Forest": 2,
+        "Domain": 2,
+        "DNS": 1,
         "CA": 0
     },
     "HealthCheck": {

--- a/AsBuiltReport.Microsoft.AD.psd1
+++ b/AsBuiltReport.Microsoft.AD.psd1
@@ -67,7 +67,12 @@
         @{
             ModuleName = 'Diagrammer.Microsoft.AD';
             ModuleVersion = '0.2.3'
+        },
+        @{
+            ModuleName = 'Diagrammer.Core';
+            ModuleVersion = '0.2.1'
         }
+
     )
 
     # Assemblies that must be loaded prior to importing this module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.2] - 2024-06-16
+## [0.8.2] - 2024-06-15
+
+### Added
+
+- Add Diagrammer.Core to the module RequiredModules list
 
 ### Changed
 
-- Improved code to better handle errors
+- Improve the code to better handle errors
+- Update the Eomm/why-don-t-you-tweet action to v2.0.0
+- Increase the default InfoLevel for the Forest and Domain section (InfoLevel 2)
+- Enable DNS section by default (InfoLevel 1)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix [#174](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/174)
 - Fix [#176](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/176)
 - Fix [#178](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/178)
+- Fix [#180](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/180)
 
 ## [0.8.1] - 2024-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.8.1] - 2024-05-16
+## [0.8.2] - 2024-06-16
 
 ### Changed
 
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix [#160](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/160)
 - Fix [#168](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/168)
 - Fix [#171](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/171)
 - Fix [#172](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/172)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 Microsoft AD As Built Report is a PowerShell module which works in conjunction with [AsBuiltReport.Core](https://github.com/AsBuiltReport/AsBuiltReport.Core).
 
-[AsBuiltReport](https://github.com/AsBuiltReport/AsBuiltReport) is an open-sourced community project which utilises PowerShell to produce as-built documentation in multiple document formats for multiple vendors and technologies.
+[AsBuiltReport](https://github.com/AsBuiltReport/AsBuiltReport) is an open-sourced community project which utilizes PowerShell to produce as-built documentation in multiple document formats for multiple vendors and technologies.
 
 Please refer to the AsBuiltReport [website](https://www.asbuiltreport.com) for more detailed information about this project.
 
@@ -178,20 +178,22 @@ The **InfoLevel** schema allows configuration of each section of the report at a
 
 There are 4 levels (0-3) of detail granularity for each section as follows;
 
-| Setting | InfoLevel   | Description                                                          |
-| :-----: | ----------- | -------------------------------------------------------------------- |
-|    0    | Disabled    | Does not collect or display any information                          |
-|    1    | Enabled     | Provides summarised information for a collection of objects          |
-|    2    | Adv Summary | Provides condensed, detailed information for a collection of objects |
-|    3    | Detailed    | Provides detailed information for individual objects                 |
+| Setting | InfoLevel    | Description                                                                                         |
+| :-----: | ------------ | --------------------------------------------------------------------------------------------------- |
+|    0    | Disabled     | Does not collect or display any information                                                         |
+|    1    | Enabled      | Provides summarized information for a collection of objects                                         |
+|    2    | Adv Summary  | Provides condensed, detailed information for a collection of objects                                |
+|    3    | Detailed     | Provides detailed information for individual objects                                                |
+|    4    | Adv Detailed | Provides detailed information for individual objects, as well as information for associated objects |
+
 
 The table below outlines the default and maximum **InfoLevel** settings for each section.
 
 | Sub-Schema | Default Setting | Maximum Setting |
 | ---------- | :-------------: | :-------------: |
-| Forest     |        1        |        1        |
-| Domain     |        1        |        3        |
-| DNS        |        0        |        2        |
+| Forest     |        2        |        1        |
+| Domain     |        2        |        4        |
+| DNS        |        1        |        2        |
 | CA         |        0        |        3        |
 
 ### Healthcheck

--- a/Src/Private/Get-AbrADDCRoleFeature.ps1
+++ b/Src/Private/Get-AbrADDCRoleFeature.ps1
@@ -29,7 +29,12 @@ function Get-AbrADDCRoleFeature {
 
     process {
         try {
-            $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'ADDCRoleFeature'
+            $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'ADDCRoleFeature' -ErrorAction Stop } catch {
+                if (-Not $_.Exception.MessageId) {
+                    $ErrorMessage = $_.FullyQualifiedErrorId
+                } else {$ErrorMessage = $_.Exception.MessageId}
+                Write-PScriboMessage -IsWarning "Roles Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+            }
             if ($DCPssSession) {
                 $Features = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-WindowsFeature | Where-Object { $_.installed -eq "True" -and $_.FeatureType -eq 'Role' } }
                 Remove-PSSession -Session $DCPssSession

--- a/Src/Private/Get-AbrADDFSHealth.ps1
+++ b/Src/Private/Get-AbrADDFSHealth.ps1
@@ -43,9 +43,9 @@ function Get-AbrADDFSHealth {
                                 $inObj = [ordered] @{
                                     'DC Name' = $DCStatus.DomainController
                                     'Replication Status' = Switch ([string]::IsNullOrEmpty($DCStatus.ReplicationState)) {
-                                        $true {"Unknown"}
-                                        $false {$DCStatus.ReplicationState}
-                                        default {"--"}
+                                        $true { "Unknown" }
+                                        $false { $DCStatus.ReplicationState }
+                                        default { "--" }
                                     }
                                     'GPO Count' = $DCStatus.GroupPolicyCount
                                     'Sysvol Count' = $DCStatus.SysvolCount
@@ -104,7 +104,13 @@ function Get-AbrADDFSHealth {
             }
             try {
                 $DC = Invoke-Command -Session $TempPssSession { (Get-ADDomain -Identity $using:Domain).ReplicaDirectoryServers | Select-Object -First 1 }
-                $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainSysvolHealth'
+                $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainSysvolHealth' -ErrorAction Stop } catch {
+                    if (-Not $_.Exception.MessageId) {
+                        $ErrorMessage = $_.FullyQualifiedErrorId
+                    } else {$ErrorMessage = $_.Exception.MessageId}
+                    Write-PScriboMessage -IsWarning "Sysvol Content Status Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+                }
+                # $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainSysvolHealth' -ErrorAction Stop } catch { Write-PScriboMessage -IsWarning "Sysvol Content Status Section: New-PSSession: Unable to connect to $($DC): $($_.Exception.MessageId)" }
                 # Code taken from ClaudioMerola (https://github.com/ClaudioMerola/ADxRay)
                 if ($DCPssSession) {
                     $SYSVOLFolder = Invoke-Command -Session $DCPssSession { Get-ChildItem -Path $('\\' + $using:Domain + '\SYSVOL\' + $using:Domain) -Recurse | Where-Object -FilterScript { $_.PSIsContainer -eq $false } | Group-Object -Property Extension | ForEach-Object -Process {
@@ -166,7 +172,13 @@ function Get-AbrADDFSHealth {
             }
             try {
                 $DC = Invoke-Command -Session $TempPssSession { (Get-ADDomain -Identity $using:Domain).ReplicaDirectoryServers | Select-Object -First 1 }
-                $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'NetlogonHealth'
+                $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'NetlogonHealth' -ErrorAction Stop } catch {
+                    if (-Not $_.Exception.MessageId) {
+                        $ErrorMessage = $_.FullyQualifiedErrorId
+                    } else {$ErrorMessage = $_.Exception.MessageId}
+                    Write-PScriboMessage -IsWarning "Netlogon Content Status Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+                }
+                # $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'NetlogonHealth' -ErrorAction Stop } catch { Write-PScriboMessage -IsWarning "Netlogon Content Status Section: New-PSSession: Unable to connect to $($DC): $($_.Exception.MessageId)" }
                 # Code taken from ClaudioMerola (https://github.com/ClaudioMerola/ADxRay)
                 if ($DCPssSession) {
                     $NetlogonFolder = Invoke-Command -Session $DCPssSession { Get-ChildItem -Path $('\\' + $using:Domain + '\NETLOGON\') -Recurse | Where-Object -FilterScript { $_.PSIsContainer -eq $false } | Group-Object -Property Extension | ForEach-Object -Process {

--- a/Src/Private/Get-AbrADDFSHealth.ps1
+++ b/Src/Private/Get-AbrADDFSHealth.ps1
@@ -110,7 +110,6 @@ function Get-AbrADDFSHealth {
                     } else {$ErrorMessage = $_.Exception.MessageId}
                     Write-PScriboMessage -IsWarning "Sysvol Content Status Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                 }
-                # $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainSysvolHealth' -ErrorAction Stop } catch { Write-PScriboMessage -IsWarning "Sysvol Content Status Section: New-PSSession: Unable to connect to $($DC): $($_.Exception.MessageId)" }
                 # Code taken from ClaudioMerola (https://github.com/ClaudioMerola/ADxRay)
                 if ($DCPssSession) {
                     $SYSVOLFolder = Invoke-Command -Session $DCPssSession { Get-ChildItem -Path $('\\' + $using:Domain + '\SYSVOL\' + $using:Domain) -Recurse | Where-Object -FilterScript { $_.PSIsContainer -eq $false } | Group-Object -Property Extension | ForEach-Object -Process {
@@ -178,7 +177,6 @@ function Get-AbrADDFSHealth {
                     } else {$ErrorMessage = $_.Exception.MessageId}
                     Write-PScriboMessage -IsWarning "Netlogon Content Status Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                 }
-                # $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'NetlogonHealth' -ErrorAction Stop } catch { Write-PScriboMessage -IsWarning "Netlogon Content Status Section: New-PSSession: Unable to connect to $($DC): $($_.Exception.MessageId)" }
                 # Code taken from ClaudioMerola (https://github.com/ClaudioMerola/ADxRay)
                 if ($DCPssSession) {
                     $NetlogonFolder = Invoke-Command -Session $DCPssSession { Get-ChildItem -Path $('\\' + $using:Domain + '\NETLOGON\') -Recurse | Where-Object -FilterScript { $_.PSIsContainer -eq $false } | Group-Object -Property Extension | ForEach-Object -Process {

--- a/Src/Private/Get-AbrADDNSZone.ps1
+++ b/Src/Private/Get-AbrADDNSZone.ps1
@@ -37,7 +37,6 @@ function Get-AbrADDNSZone {
                 } else {$ErrorMessage = $_.Exception.MessageId}
                 Write-PScriboMessage -IsWarning "DNS Zones Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
             }
-            # $DCPssSession = try { New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DDNSInfrastructure' -ErrorAction Stop } catch { Write-PScriboMessage -IsWarning "DNS Zones Section: New-PsSession: Unable to connect to $($DC): $($_.Exception.MessageId)" }
             $DNSSetting = Get-DnsServerZone -CimSession $TempCIMSession -ComputerName $DC | Where-Object { $_.IsReverseLookupZone -like "False" -and $_.ZoneType -notlike "Forwarder" }
             if ($DNSSetting) {
                 Section -Style Heading3 "$($DC.ToString().ToUpper().Split(".")[0]) DNS Zones" {

--- a/Src/Private/Get-AbrADDomainController.ps1
+++ b/Src/Private/Get-AbrADDomainController.ps1
@@ -75,7 +75,6 @@ function Get-AbrADDomainController {
                             } else {$ErrorMessage = $_.Exception.MessageId}
                             Write-PScriboMessage -IsWarning "DC Net Settings Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                         }
-                        # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DCNetSettings'
                         if ($DCPssSession ) {
                             $DCNetSettings = try { Invoke-Command -Session $DCPssSession { Get-NetIPAddress } } catch { Write-PScriboMessage -IsWarning "Unable to get $DC network interfaces information" }
                             Remove-PSSession -Session $DCPssSession
@@ -161,7 +160,6 @@ function Get-AbrADDomainController {
                             } else {$ErrorMessage = $_.Exception.MessageId}
                             Write-PScriboMessage -IsWarning "DC Net Settings Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                         }
-                        # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DCNetSettings'
                         if ($DCPssSession) {
                             $DCNetSettings = try { Invoke-Command -Session $DCPssSession -ErrorAction Stop { Get-NetIPAddress } } catch { Out-Null }
                             $DCNetSMBv1Setting = try { Invoke-Command -Session $DCPssSession -ErrorAction Stop { Get-WindowsOptionalFeature -Online -FeatureName SMB1Protocol } } catch { Out-Null }
@@ -306,7 +304,7 @@ function Get-AbrADDomainController {
                                                         default { "Unknown" }
                                                     }
                                                     "LDAP Port" = $DCInfo.LdapPort
-                                                    "SSL Port" = $DCInfo.SslPort
+                                                    "LDAPS Port" = $DCInfo.SslPort
                                                 }
                                                 $OutObj = [pscustomobject]$inobj
 
@@ -347,7 +345,6 @@ function Get-AbrADDomainController {
                                                 } else {$ErrorMessage = $_.Exception.MessageId}
                                                 Write-PScriboMessage -IsWarning "Domain Controller Hardware Inventory Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                                             }
-                                            # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerHardware'
                                             if ($DCPssSession) {
                                                 $HW = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-ComputerInfo }
                                                 $HWCPU = Get-CimInstance -Class Win32_Processor -CimSession $CimSession
@@ -441,7 +438,6 @@ function Get-AbrADDomainController {
                         } else {$ErrorMessage = $_.Exception.MessageId}
                         Write-PScriboMessage -IsWarning "DNS IP Configuration Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                     }
-                    # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DNSIPConfiguration'
                     try {
                         if ($DCPssSession) {
                             $DCIPAddress = Invoke-Command -Session $DCPssSession { [System.Net.Dns]::GetHostAddresses($using:DC).IPAddressToString }
@@ -551,7 +547,6 @@ function Get-AbrADDomainController {
                             } else {$ErrorMessage = $_.Exception.MessageId}
                             Write-PScriboMessage -IsWarning "NTDS Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                         }
-                        # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'NTDS'
                         if ($DCPssSession) {
                             $NTDS = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-ItemProperty -Path HKLM:\System\CurrentControlSet\Services\NTDS\Parameters | Select-Object -ExpandProperty 'DSA Database File' }
                             $size = Invoke-Command -Session $DCPssSession -ScriptBlock { (Get-ItemProperty -Path $using:NTDS).Length }
@@ -602,7 +597,6 @@ function Get-AbrADDomainController {
                             } else {$ErrorMessage = $_.Exception.MessageId}
                             Write-PScriboMessage -IsWarning "Time Source Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                         }
-                        # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'TimeSource'
                         if ($DCPssSession) {
                             $NtpServer = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-ItemProperty -Path HKLM:\System\CurrentControlSet\Services\W32Time\Parameters | Select-Object -ExpandProperty 'NtpServer' }
                             $SourceType = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-ItemProperty -Path HKLM:\System\CurrentControlSet\Services\W32Time\Parameters | Select-Object -ExpandProperty 'Type' }
@@ -779,7 +773,6 @@ function Get-AbrADDomainController {
                                 } else {$ErrorMessage = $_.Exception.MessageId}
                                 Write-PScriboMessage -IsWarning "Domain Controllers File Shares Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                             }
-                            # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllersFileShares'
                             if ($DCPssSession) {
                                 $Shares = Invoke-Command -Session $DCPssSession -ErrorAction Stop { Get-SmbShare | Where-Object { $_.Description -ne 'Default share' -and $_.Description -notmatch 'Remote' -and $_.Name -ne 'NETLOGON' -and $_.Name -ne 'SYSVOL' } }
                             }
@@ -849,7 +842,6 @@ function Get-AbrADDomainController {
                                 } else {$ErrorMessage = $_.Exception.MessageId}
                                 Write-PScriboMessage -IsWarning "Domain Controller Installed Software Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                             }
-                            # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerInstalledSoftware'
                             if ($DCPssSession) {
                                 $SoftwareX64 = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { ($_.Publisher -notlike "Microsoft*" -and $_.DisplayName -notlike "VMware*" -and $_.DisplayName -notlike "Microsoft*") -and ($Null -ne $_.Publisher -or $Null -ne $_.DisplayName) } | Select-Object -Property DisplayName, Publisher, InstallDate | Sort-Object -Property DisplayName }
                                 $SoftwareX86 = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { ($_.Publisher -notlike "Microsoft*" -and $_.DisplayName -notlike "VMware*" -and $_.DisplayName -notlike "Microsoft*") -and ($Null -ne $_.Publisher -or $Null -ne $_.DisplayName) } | Select-Object -Property DisplayName, Publisher, InstallDate | Sort-Object -Property DisplayName }
@@ -928,7 +920,6 @@ function Get-AbrADDomainController {
                                 } else {$ErrorMessage = $_.Exception.MessageId}
                                 Write-PScriboMessage -IsWarning "Domain Controller Pending Missing Patch Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                             }
-                            # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerPendingMissingPatch'
                             if ($DCPssSession ) {
                                 $Updates = Invoke-Command -Session $DCPssSession -ScriptBlock { (New-Object -ComObject Microsoft.Update.Session).CreateupdateSearcher().Search("IsHidden=0 and IsInstalled=0").Updates | Select-Object Title, KBArticleIDs }
                                 Remove-PSSession -Session $DCPssSession

--- a/Src/Private/Get-AbrADDomainController.ps1
+++ b/Src/Private/Get-AbrADDomainController.ps1
@@ -69,7 +69,13 @@ function Get-AbrADDomainController {
                 foreach ($DC in $DCs) {
                     if (Test-Connection -ComputerName $DC -Quiet -Count 2) {
                         $DCInfo = Invoke-Command -Session $TempPssSession { Get-ADDomainController -Identity $using:DC -Server $using:DC }
-                        $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DCNetSettings'
+                        $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DCNetSettings' -ErrorAction Stop } catch {
+                            if (-Not $_.Exception.MessageId) {
+                                $ErrorMessage = $_.FullyQualifiedErrorId
+                            } else {$ErrorMessage = $_.Exception.MessageId}
+                            Write-PScriboMessage -IsWarning "DC Net Settings Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+                        }
+                        # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DCNetSettings'
                         if ($DCPssSession ) {
                             $DCNetSettings = try { Invoke-Command -Session $DCPssSession { Get-NetIPAddress } } catch { Write-PScriboMessage -IsWarning "Unable to get $DC network interfaces information" }
                             Remove-PSSession -Session $DCPssSession
@@ -149,7 +155,13 @@ function Get-AbrADDomainController {
                     if (Test-Connection -ComputerName $DC -Quiet -Count 2) {
                         $DCInfo = Invoke-Command -Session $TempPssSession { Get-ADDomainController -Identity $using:DC -Server $using:DC }
                         $DCComputerObject = try { Invoke-Command -Session $TempPssSession -ErrorAction Stop { Get-ADComputer ($using:DCInfo).ComputerObjectDN -Properties * -Server $using:DC } } catch { Out-Null }
-                        $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DCNetSettings'
+                        $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DCNetSettings' -ErrorAction Stop } catch {
+                            if (-Not $_.Exception.MessageId) {
+                                $ErrorMessage = $_.FullyQualifiedErrorId
+                            } else {$ErrorMessage = $_.Exception.MessageId}
+                            Write-PScriboMessage -IsWarning "DC Net Settings Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+                        }
+                        # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DCNetSettings'
                         if ($DCPssSession) {
                             $DCNetSettings = try { Invoke-Command -Session $DCPssSession -ErrorAction Stop { Get-NetIPAddress } } catch { Out-Null }
                             $DCNetSMBv1Setting = try { Invoke-Command -Session $DCPssSession -ErrorAction Stop { Get-WindowsOptionalFeature -Online -FeatureName SMB1Protocol } } catch { Out-Null }
@@ -328,8 +340,14 @@ function Get-AbrADDomainController {
                                     try {
                                         $DCHWInfo = @()
                                         try {
-                                            $CimSession = New-CimSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerHardware'
-                                            $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerHardware'
+                                            $CimSession = try { New-CimSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerHardware' -ErrorAction Stop } catch { Write-PScriboMessage -IsWarning "Hardware Inventory Section: New-CimSession: Unable to connect to $($DC): $($_.Exception.MessageId)" }
+                                            $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerHardware' -ErrorAction Stop } catch {
+                                                if (-Not $_.Exception.MessageId) {
+                                                    $ErrorMessage = $_.FullyQualifiedErrorId
+                                                } else {$ErrorMessage = $_.Exception.MessageId}
+                                                Write-PScriboMessage -IsWarning "Domain Controller Hardware Inventory Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+                                            }
+                                            # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerHardware'
                                             if ($DCPssSession) {
                                                 $HW = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-ComputerInfo }
                                                 $HWCPU = Get-CimInstance -Class Win32_Processor -CimSession $CimSession
@@ -417,7 +435,13 @@ function Get-AbrADDomainController {
             $OutObj = @()
             foreach ($DC in $DCs) {
                 if (Test-Connection -ComputerName $DC -Quiet -Count 2) {
-                    $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DNSIPConfiguration'
+                    $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DNSIPConfiguration' -ErrorAction Stop } catch {
+                        if (-Not $_.Exception.MessageId) {
+                            $ErrorMessage = $_.FullyQualifiedErrorId
+                        } else {$ErrorMessage = $_.Exception.MessageId}
+                        Write-PScriboMessage -IsWarning "DNS IP Configuration Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+                    }
+                    # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DNSIPConfiguration'
                     try {
                         if ($DCPssSession) {
                             $DCIPAddress = Invoke-Command -Session $DCPssSession { [System.Net.Dns]::GetHostAddresses($using:DC).IPAddressToString }
@@ -521,7 +545,13 @@ function Get-AbrADDomainController {
             foreach ($DC in $DCs) {
                 if (Test-Connection -ComputerName $DC -Quiet -Count 2) {
                     try {
-                        $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'NTDS'
+                        $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'NTDS' -ErrorAction Stop } catch {
+                            if (-Not $_.Exception.MessageId) {
+                                $ErrorMessage = $_.FullyQualifiedErrorId
+                            } else {$ErrorMessage = $_.Exception.MessageId}
+                            Write-PScriboMessage -IsWarning "NTDS Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+                        }
+                        # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'NTDS'
                         if ($DCPssSession) {
                             $NTDS = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-ItemProperty -Path HKLM:\System\CurrentControlSet\Services\NTDS\Parameters | Select-Object -ExpandProperty 'DSA Database File' }
                             $size = Invoke-Command -Session $DCPssSession -ScriptBlock { (Get-ItemProperty -Path $using:NTDS).Length }
@@ -566,7 +596,13 @@ function Get-AbrADDomainController {
             foreach ($DC in $DCs) {
                 if (Test-Connection -ComputerName $DC -Quiet -Count 2) {
                     try {
-                        $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'TimeSource'
+                        $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'TimeSource' -ErrorAction Stop } catch {
+                            if (-Not $_.Exception.MessageId) {
+                                $ErrorMessage = $_.FullyQualifiedErrorId
+                            } else {$ErrorMessage = $_.Exception.MessageId}
+                            Write-PScriboMessage -IsWarning "Time Source Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+                        }
+                        # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'TimeSource'
                         if ($DCPssSession) {
                             $NtpServer = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-ItemProperty -Path HKLM:\System\CurrentControlSet\Services\W32Time\Parameters | Select-Object -ExpandProperty 'NtpServer' }
                             $SourceType = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-ItemProperty -Path HKLM:\System\CurrentControlSet\Services\W32Time\Parameters | Select-Object -ExpandProperty 'Type' }
@@ -622,7 +658,7 @@ function Get-AbrADDomainController {
                 foreach ($DC in $DCs) {
                     if (Test-Connection -ComputerName $DC -Quiet -Count 2) {
                         try {
-                            $CimSession = New-CimSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication  -Name 'SRVRecordsStatus'
+                            $CimSession = try { New-CimSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication  -Name 'SRVRecordsStatus' -ErrorAction Stop } catch { Write-PScriboMessage -IsWarning "SRV Records Status Section: New-CimSession: Unable to connect to $($DC): $($_.Exception.MessageId)" }
                             $PDCEmulator = Invoke-Command -Session $TempPssSession { (Get-ADDomain $using:Domain -ErrorAction Stop).PDCEmulator }
                             if ($CimSession -and ($Domain -eq $ADSystem.RootDomain)) {
                                 $SRVRR = Get-DnsServerResourceRecord -CimSession $CimSession -ZoneName _msdcs.$Domain -RRType Srv
@@ -737,7 +773,13 @@ function Get-AbrADDomainController {
                 $OutObj = foreach ($DC in $DCs) {
                     if (Test-Connection -ComputerName $DC -Quiet -Count 2) {
                         try {
-                            $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllersFileShares'
+                            $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllersFileShares' -ErrorAction Stop } catch {
+                                if (-Not $_.Exception.MessageId) {
+                                    $ErrorMessage = $_.FullyQualifiedErrorId
+                                } else {$ErrorMessage = $_.Exception.MessageId}
+                                Write-PScriboMessage -IsWarning "Domain Controllers File Shares Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+                            }
+                            # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllersFileShares'
                             if ($DCPssSession) {
                                 $Shares = Invoke-Command -Session $DCPssSession -ErrorAction Stop { Get-SmbShare | Where-Object { $_.Description -ne 'Default share' -and $_.Description -notmatch 'Remote' -and $_.Name -ne 'NETLOGON' -and $_.Name -ne 'SYSVOL' } }
                             }
@@ -801,7 +843,13 @@ function Get-AbrADDomainController {
                     if (Test-Connection -ComputerName $DC -Quiet -Count 2) {
                         try {
                             $Software = @()
-                            $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerInstalledSoftware'
+                            $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerInstalledSoftware' -ErrorAction Stop } catch {
+                                if (-Not $_.Exception.MessageId) {
+                                    $ErrorMessage = $_.FullyQualifiedErrorId
+                                } else {$ErrorMessage = $_.Exception.MessageId}
+                                Write-PScriboMessage -IsWarning "Domain Controller Installed Software Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+                            }
+                            # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerInstalledSoftware'
                             if ($DCPssSession) {
                                 $SoftwareX64 = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { ($_.Publisher -notlike "Microsoft*" -and $_.DisplayName -notlike "VMware*" -and $_.DisplayName -notlike "Microsoft*") -and ($Null -ne $_.Publisher -or $Null -ne $_.DisplayName) } | Select-Object -Property DisplayName, Publisher, InstallDate | Sort-Object -Property DisplayName }
                                 $SoftwareX86 = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-ItemProperty HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\* | Where-Object { ($_.Publisher -notlike "Microsoft*" -and $_.DisplayName -notlike "VMware*" -and $_.DisplayName -notlike "Microsoft*") -and ($Null -ne $_.Publisher -or $Null -ne $_.DisplayName) } | Select-Object -Property DisplayName, Publisher, InstallDate | Sort-Object -Property DisplayName }
@@ -874,7 +922,13 @@ function Get-AbrADDomainController {
                     if (Test-Connection -ComputerName $DC -Quiet -Count 2) {
                         try {
                             $Software = @()
-                            $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerPendingMissingPatch'
+                            $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerPendingMissingPatch' -ErrorAction Stop } catch {
+                                if (-Not $_.Exception.MessageId) {
+                                    $ErrorMessage = $_.FullyQualifiedErrorId
+                                } else {$ErrorMessage = $_.Exception.MessageId}
+                                Write-PScriboMessage -IsWarning "Domain Controller Pending Missing Patch Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+                            }
+                            # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerPendingMissingPatch'
                             if ($DCPssSession ) {
                                 $Updates = Invoke-Command -Session $DCPssSession -ScriptBlock { (New-Object -ComObject Microsoft.Update.Session).CreateupdateSearcher().Search("IsHidden=0 and IsInstalled=0").Updates | Select-Object Title, KBArticleIDs }
                                 Remove-PSSession -Session $DCPssSession

--- a/Src/Private/Get-AbrADDomainObject.ps1
+++ b/Src/Private/Get-AbrADDomainObject.ps1
@@ -651,6 +651,9 @@ function Get-AbrADDomainObject {
                                     BlankLine
                                     Paragraph "There is no technical reason preventing the use of circular references between AD groups, Active Directory can still calculate and grant access. The main reason that circular references are considered harmful is that they tend to make management more difficult."
                                     BlankLine
+
+                                    $OutObj | Set-Style -Style Warning
+
                                     $TableParams = @{
                                         Name = "Circular Group Membership - $($Domain.ToString().ToUpper())"
                                         List = $false
@@ -942,7 +945,7 @@ function Get-AbrADDomainObject {
                                 }
                                 $OutObj += [pscustomobject]$inobj
 
-                                if ($HealthCheck.Domain.Security -and ($PasswordPolicy.MaxPasswordAge -gt 90)) {
+                                if ($HealthCheck.Domain.Security -and ($PasswordPolicy.MaxPasswordAge.Days -gt 90)) {
                                     $OutObj | Set-Style -Style Warning -Property 'Maximun Password Age'
                                 }
 
@@ -956,7 +959,7 @@ function Get-AbrADDomainObject {
                                 }
                                 $OutObj | Table @TableParams
 
-                                if ($HealthCheck.Domain.Security -and ($PasswordPolicy.MaxPasswordAge -gt 90)) {
+                                if ($HealthCheck.Domain.Security -and ($PasswordPolicy.MaxPasswordAge.Days -gt 90)) {
                                     Paragraph "Health Check:" -Bold -Underline
                                     BlankLine
                                     Paragraph {

--- a/Src/Private/Get-AbrADFSMO.ps1
+++ b/Src/Private/Get-AbrADFSMO.ps1
@@ -39,7 +39,6 @@ function Get-AbrADFSMO {
                     } else { $ErrorMessage = $_.Exception.MessageId }
                     Write-PScriboMessage -IsWarning "FSMO Roles Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                 }
-                # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'FSMORoles' -ErrorAction SilentlyContinue
                 Section -Style Heading3 'FSMO Roles' {
                     if ($DCPssSession) { $IsInfraMasterGC = (Invoke-Command -Session $DCPssSession -ErrorAction Stop { Get-ADDomainController -Identity ($using:DomainData).InfrastructureMaster }).IsGlobalCatalog }
                     $OutObj = @()

--- a/Src/Private/Get-AbrADGPO.ps1
+++ b/Src/Private/Get-AbrADGPO.ps1
@@ -196,7 +196,13 @@ function Get-AbrADGPO {
                     if ($InfoLevel.Domain -ge 2) {
                         try {
                             $DC = Invoke-Command -Session $TempPssSession { (Get-ADDomain -Identity $using:Domain).ReplicaDirectoryServers | Select-Object -First 1 }
-                            $DCPssSession = New-PSSession -ComputerName $DC -Name "WmiFilters" -Credential $Credential -Authentication $Options.PSDefaultAuthentication
+                            $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'WmiFilters' -ErrorAction Stop } catch {
+                                if (-Not $_.Exception.MessageId) {
+                                    $ErrorMessage = $_.FullyQualifiedErrorId
+                                } else {$ErrorMessage = $_.Exception.MessageId}
+                                Write-PScriboMessage -IsWarning "Wmi Filters Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+                            }
+                            # $DCPssSession = New-PSSession -ComputerName $DC -Name "WmiFilters" -Credential $Credential -Authentication $Options.PSDefaultAuthentication
                             $DomainInfo = Invoke-Command -Session $TempPssSession { Get-ADDomain $using:Domain -ErrorAction Stop }
                             if ($DCPssSession) {
                                 $WmiFilters = Get-ADObjectSearch -DN "CN=SOM,CN=WMIPolicy,CN=System,$($DomainInfo.DistinguishedName)" -Filter { objectClass -eq "msWMI-Som" } -SelectPrty '*' -Session $DCPssSession | Sort-Object
@@ -543,7 +549,13 @@ function Get-AbrADGPO {
                     # https://github.com/jeremyts/ActiveDirectoryDomainServices/blob/master/Audit/FindOrphanedGPOs.ps1
                     try {
                         $DC = Invoke-Command -Session $TempPssSession { (Get-ADDomain -Identity $using:Domain).ReplicaDirectoryServers | Select-Object -First 1 }
-                        $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'OrphanedGPO'
+                        $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'OrphanedGPO' -ErrorAction Stop } catch {
+                            if (-Not $_.Exception.MessageId) {
+                                $ErrorMessage = $_.FullyQualifiedErrorId
+                            } else {$ErrorMessage = $_.Exception.MessageId}
+                            Write-PScriboMessage -IsWarning "Orphaned GPO Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+                        }
+                        # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'OrphanedGPO'
                         $DomainInfo = Invoke-Command -Session $TempPssSession { Get-ADDomain $using:Domain -ErrorAction Stop }
                         $GPOPoliciesSYSVOLUNC = "\\$Domain\SYSVOL\$Domain\Policies"
                         $OrphanGPOs = @()

--- a/Src/Private/Get-AbrADGPO.ps1
+++ b/Src/Private/Get-AbrADGPO.ps1
@@ -202,7 +202,6 @@ function Get-AbrADGPO {
                                 } else {$ErrorMessage = $_.Exception.MessageId}
                                 Write-PScriboMessage -IsWarning "Wmi Filters Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                             }
-                            # $DCPssSession = New-PSSession -ComputerName $DC -Name "WmiFilters" -Credential $Credential -Authentication $Options.PSDefaultAuthentication
                             $DomainInfo = Invoke-Command -Session $TempPssSession { Get-ADDomain $using:Domain -ErrorAction Stop }
                             if ($DCPssSession) {
                                 $WmiFilters = Get-ADObjectSearch -DN "CN=SOM,CN=WMIPolicy,CN=System,$($DomainInfo.DistinguishedName)" -Filter { objectClass -eq "msWMI-Som" } -SelectPrty '*' -Session $DCPssSession | Sort-Object
@@ -555,7 +554,6 @@ function Get-AbrADGPO {
                             } else {$ErrorMessage = $_.Exception.MessageId}
                             Write-PScriboMessage -IsWarning "Orphaned GPO Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                         }
-                        # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'OrphanedGPO'
                         $DomainInfo = Invoke-Command -Session $TempPssSession { Get-ADDomain $using:Domain -ErrorAction Stop }
                         $GPOPoliciesSYSVOLUNC = "\\$Domain\SYSVOL\$Domain\Policies"
                         $OrphanGPOs = @()

--- a/Src/Private/Get-AbrADInfrastructureService.ps1
+++ b/Src/Private/Get-AbrADInfrastructureService.ps1
@@ -29,7 +29,13 @@ function Get-AbrADInfrastructureService {
 
     process {
         try {
-            $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerInfrastructureServices'
+            $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerInfrastructureServices' -ErrorAction Stop } catch {
+                if (-Not $_.Exception.MessageId) {
+                    $ErrorMessage = $_.FullyQualifiedErrorId
+                } else { $ErrorMessage = $_.Exception.MessageId }
+                Write-PScriboMessage -IsWarning "Domain Controller Infrastructure Services Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+            }
+            # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerInfrastructureServices'
             if ($DCPssSession) {
                 $Available = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-Service "W32Time" | Select-Object DisplayName, Name, Status }
             }

--- a/Src/Private/Get-AbrADInfrastructureService.ps1
+++ b/Src/Private/Get-AbrADInfrastructureService.ps1
@@ -35,7 +35,6 @@ function Get-AbrADInfrastructureService {
                 } else { $ErrorMessage = $_.Exception.MessageId }
                 Write-PScriboMessage -IsWarning "Domain Controller Infrastructure Services Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
             }
-            # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'DomainControllerInfrastructureServices'
             if ($DCPssSession) {
                 $Available = Invoke-Command -Session $DCPssSession -ScriptBlock { Get-Service "W32Time" | Select-Object DisplayName, Name, Status }
             }

--- a/Src/Private/Get-AbrADSite.ps1
+++ b/Src/Private/Get-AbrADSite.ps1
@@ -27,8 +27,7 @@ function Get-AbrADSite {
             $Site = Invoke-Command -Session $TempPssSession { Get-ADReplicationSite -Filter * -Properties * }
             if ($Site) {
                 Section -Style Heading3 'Replication' {
-                    Paragraph "Replication is the process of transferring and updating Active Directory objects between
-                    domain controllers in the Active Directory domain and forest. The folowing setion details Active Directory replication and it´s relationships."
+                    Paragraph "Replication is the process of transferring and updating Active Directory objects between domain controllers in the Active Directory domain and forest. The folowing setion details Active Directory replication and it's relationships."
                     BlankLine
                     Section -Style Heading4 'Sites' {
                         $OutObj = @()
@@ -219,7 +218,6 @@ function Get-AbrADSite {
                                                             } else { $ErrorMessage = $_.Exception.MessageId }
                                                             Write-PScriboMessage -IsWarning "Missing Subnet in AD Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                                                         }
-                                                        # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'MissingSubnetinAD'
                                                         $Path = "\\$DC\admin`$\debug\netlogon.log"
                                                         if ((Invoke-Command -Session $DCPssSession { Test-Path -Path $using:path }) -and (Invoke-Command -Session $DCPssSession { (Get-Content -Path $using:path | Measure-Object -Line).lines -gt 0 })) {
                                                             $NetLogonContents = Invoke-Command -Session $DCPssSession { (Get-Content -Path $using:Path)[-200..-1] }

--- a/Src/Private/Get-AbrADSite.ps1
+++ b/Src/Private/Get-AbrADSite.ps1
@@ -213,7 +213,13 @@ function Get-AbrADSite {
                                             foreach ($DC in ($DomainInfo.ReplicaDirectoryServers | Where-Object { $_ -notin $Options.Exclude.DCs })) {
                                                 if (Test-Connection -ComputerName $DC -Quiet -Count 2) {
                                                     try {
-                                                        $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'MissingSubnetinAD'
+                                                        $DCPssSession = try { New-PSSession -ComputerName $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'MissingSubnetinAD' -ErrorAction Stop } catch {
+                                                            if (-Not $_.Exception.MessageId) {
+                                                                $ErrorMessage = $_.FullyQualifiedErrorId
+                                                            } else { $ErrorMessage = $_.Exception.MessageId }
+                                                            Write-PScriboMessage -IsWarning "Missing Subnet in AD Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
+                                                        }
+                                                        # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'MissingSubnetinAD'
                                                         $Path = "\\$DC\admin`$\debug\netlogon.log"
                                                         if ((Invoke-Command -Session $DCPssSession { Test-Path -Path $using:path }) -and (Invoke-Command -Session $DCPssSession { (Get-Content -Path $using:path | Measure-Object -Line).lines -gt 0 })) {
                                                             $NetLogonContents = Invoke-Command -Session $DCPssSession { (Get-Content -Path $using:Path)[-200..-1] }
@@ -302,7 +308,7 @@ function Get-AbrADSite {
                     }
                     try {
                         $DomainDN = Invoke-Command -Session $TempPssSession { (Get-ADDomain -Identity (Get-ADForest | Select-Object -ExpandProperty RootDomain )).DistinguishedName }
-                        $InterSiteTransports = try {Invoke-Command -Session $TempPssSession -ErrorAction Stop { Get-ADObject -Filter { (objectClass -eq "interSiteTransport") } -SearchBase "CN=Inter-Site Transports,CN=Sites,CN=Configuration,$using:DomainDN" -Properties * }} catch {Out-Null}
+                        $InterSiteTransports = try { Invoke-Command -Session $TempPssSession -ErrorAction Stop { Get-ADObject -Filter { (objectClass -eq "interSiteTransport") } -SearchBase "CN=Inter-Site Transports,CN=Sites,CN=Configuration,$using:DomainDN" -Properties * } } catch { Out-Null }
                         if ($InterSiteTransports) {
                             Section -Style Heading4 'Inter-Site Transports' {
                                 Paragraph "Site links in Active Directory represent the inter-site connectivity and method used to transfer replication traffic.There are two transport protocols that can be used for replication via site links. The default protocol used in site link is IP, and it performs synchronous replication between available domain controllers. The SMTP method can be used when the link between sites is not reliable."
@@ -690,47 +696,51 @@ function Get-AbrADSite {
                         foreach ($Domain in $ADSystem.Domains | Where-Object { $_ -notin $Options.Exclude.Domains }) {
                             $DomainInfo = Invoke-Command -Session $TempPssSession { Get-ADDomain $using:Domain -ErrorAction Stop }
                             foreach ($DC in ($DomainInfo.ReplicaDirectoryServers | Where-Object { $_ -notin $Options.Exclude.DCs })) {
-                                if ((Test-Connection -ComputerName $DC -Quiet -Count 2) -and ($DCCIMSession = New-CimSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name "SysvolReplication")) {
-                                    $Replication = Get-CimInstance -CimSession $DCCIMSession -Namespace "root/microsoftdfs" -Class "dfsrreplicatedfolderinfo" -Filter "ReplicatedFolderName = 'SYSVOL Share'" -EA 0 -Verbose:$False | Select-Object State
+                                if (Test-Connection -ComputerName $DC -Quiet -Count 2) {
+                                    $DCCIMSession = try { New-CimSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name "SysvolReplication" -ErrorAction Stop } catch { Write-PScriboMessage -IsWarning "Sysvol Replication Section: New-CimSession: Unable to connect to $($DC): $($_.Exception.MessageId)" }
+
                                     if ($DCCIMSession) {
-                                        Remove-CimSession -CimSession $DCCIMSession
-                                    }
-
-                                    try {
-                                        $inObj = [ordered] @{
-                                            'DC Name' = $DC.split(".", 2)[0]
-                                            'Replication Status' = Switch ($Replication.State) {
-                                                0 { 'Uninitialized' }
-                                                1 { 'Initialized' }
-                                                2 { 'Initial synchronization' }
-                                                3 { 'Auto recovery' }
-                                                4 { 'Normal' }
-                                                5 { 'In error state' }
-                                                6 { 'Disabled' }
-                                                7 { 'Unknown' }
-                                            }
-                                            'Domain' = $Domain
+                                        $Replication = Get-CimInstance -CimSession $DCCIMSession -Namespace "root/microsoftdfs" -Class "dfsrreplicatedfolderinfo" -Filter "ReplicatedFolderName = 'SYSVOL Share'" -EA 0 -Verbose:$False | Select-Object State
+                                        if ($DCCIMSession) {
+                                            Remove-CimSession -CimSession $DCCIMSession
                                         }
-                                        $OutObj += [pscustomobject]$inobj
-                                    } catch {
-                                        Write-PScriboMessage -IsWarning "Sysvol Replication Item Section: $($_.Exception.Message)"
-                                    }
 
-                                    if ($HealthCheck.Site.BestPractice) {
-                                        $ReplicationStatusError = @(
-                                            'Uninitialized',
-                                            'Auto recovery',
-                                            'In error state',
-                                            'Disabled',
-                                            'Unknown'
-                                        )
-                                        $ReplicationStatusWarn = @(
-                                            'Initialized',
-                                            'Initial synchronization'
-                                        )
-                                        $OutObj | Where-Object { $_.'Replication Status' -eq 'Normal' } | Set-Style -Style OK -Property 'Replication Status'
-                                        $OutObj | Where-Object { $_.'Replication Status' -in $ReplicationStatusError } | Set-Style -Style Critical -Property 'Replication Status'
-                                        $OutObj | Where-Object { $_.'Replication Status' -in $ReplicationStatusWarn } | Set-Style -Style Warning -Property 'Replication Status'
+                                        try {
+                                            $inObj = [ordered] @{
+                                                'DC Name' = $DC.split(".", 2)[0]
+                                                'Replication Status' = Switch ($Replication.State) {
+                                                    0 { 'Uninitialized' }
+                                                    1 { 'Initialized' }
+                                                    2 { 'Initial synchronization' }
+                                                    3 { 'Auto recovery' }
+                                                    4 { 'Normal' }
+                                                    5 { 'In error state' }
+                                                    6 { 'Disabled' }
+                                                    7 { 'Unknown' }
+                                                }
+                                                'Domain' = $Domain
+                                            }
+                                            $OutObj += [pscustomobject]$inobj
+                                        } catch {
+                                            Write-PScriboMessage -IsWarning "Sysvol Replication Item Section: $($_.Exception.Message)"
+                                        }
+
+                                        if ($HealthCheck.Site.BestPractice) {
+                                            $ReplicationStatusError = @(
+                                                'Uninitialized',
+                                                'Auto recovery',
+                                                'In error state',
+                                                'Disabled',
+                                                'Unknown'
+                                            )
+                                            $ReplicationStatusWarn = @(
+                                                'Initialized',
+                                                'Initial synchronization'
+                                            )
+                                            $OutObj | Where-Object { $_.'Replication Status' -eq 'Normal' } | Set-Style -Style OK -Property 'Replication Status'
+                                            $OutObj | Where-Object { $_.'Replication Status' -in $ReplicationStatusError } | Set-Style -Style Critical -Property 'Replication Status'
+                                            $OutObj | Where-Object { $_.'Replication Status' -in $ReplicationStatusWarn } | Set-Style -Style Warning -Property 'Replication Status'
+                                        }
                                     }
                                 }
                             }

--- a/Src/Private/Get-AbrADSite.ps1
+++ b/Src/Private/Get-AbrADSite.ps1
@@ -27,8 +27,9 @@ function Get-AbrADSite {
             $Site = Invoke-Command -Session $TempPssSession { Get-ADReplicationSite -Filter * -Properties * }
             if ($Site) {
                 Section -Style Heading3 'Replication' {
-                    Paragraph "Replication is the process of transferring and updating Active Directory objects between domain controllers in the Active Directory domain and forest. The folowing setion details Active Directory replication and it's relationships."
+                    Paragraph 'Replication is the process of transferring and updating Active Directory objects between domain controllers in the Active Directory domain and forest.'
                     BlankLine
+                    Paragraph "The folowing setion details Active Directory replication and it's relationships."
                     Section -Style Heading4 'Sites' {
                         $OutObj = @()
                         foreach ($Item in $Site) {

--- a/Src/Private/Get-AbrADSiteReplication.ps1
+++ b/Src/Private/Get-AbrADSiteReplication.ps1
@@ -125,7 +125,6 @@ function Get-AbrADSiteReplication {
                     } else { $ErrorMessage = $_.Exception.MessageId }
                     Write-PScriboMessage -IsWarning "Replication Status Section: New-PSSession: Unable to connect to $($DC): $ErrorMessage"
                 }
-                # $DCPssSession = New-PSSession $DC -Credential $Credential -Authentication $Options.PSDefaultAuthentication -Name 'ActiveDirectoryReplicationStatus'
                 if ($DCPssSession) {
                     $RepStatus = Invoke-Command -Session $DCPssSession -ScriptBlock { repadmin /showrepl /repsto /csv | ConvertFrom-Csv }
                 }

--- a/Src/Private/Get-AbrDHCPinAD.ps1
+++ b/Src/Private/Get-AbrDHCPinAD.ps1
@@ -1,0 +1,79 @@
+function Get-AbrDHCPinAD {
+    <#
+    .SYNOPSIS
+    Used by As Built Report to retrieve Microsoft AD DHCP Servers information
+    .DESCRIPTION
+
+    .NOTES
+        Version:        0.8.2
+        Author:         Jonathan Colon
+        Twitter:        @jcolonfzenpr
+        Github:         rebelinux
+    .EXAMPLE
+
+    .LINK
+
+    #>
+    [CmdletBinding()]
+    param (
+    )
+
+    begin {
+        Write-PScriboMessage "Collecting AD DHCP Servers information of $($ForestInfo.toUpper())."
+    }
+
+    process {
+        $DomainInfo = Invoke-Command -Session $TempPssSession { Get-ADDomain ($using:ADSystem).RootDomain -ErrorAction Stop }
+        if ($DomainInfo) {
+            $DHCPServers = try {
+                Get-ADObjectSearch -DN "CN=NetServices,CN=Services,CN=Configuration,$(($DomainInfo).DistinguishedName)" -Filter { objectclass -eq 'dHCPClass' -AND Name -ne 'dhcproot' } -Properties "*" -SelectPrty 'Name' -Session $TempPssSession
+            } catch { Out-Null }
+        }
+        try {
+            if ($DHCPServers ) {
+                try {
+                    $DCServersinAD = @(foreach ($Domain in $ADSystem.Domains) {
+                        (Invoke-Command -Session $TempPssSession -ErrorAction Stop { Get-ADDomain -Identity $using:Domain }).ReplicaDirectoryServers
+                    })
+                } catch { Out-Null }
+                Section -Style Heading3 'DHCP Infrastructure' {
+                    Paragraph "The following section provides a summary of the DHCP infrastructure configured on Active Directory."
+                    BlankLine
+                    $DCHPInfo = @()
+                    foreach ($DHCPServer in $DHCPServers) {
+                        try {
+                            $inObj = [ordered] @{
+                                'Server Name' = $DHCPServer.Name
+                                'Is Domain Controller?' = Switch ($DHCPServer.Name -in $DCServersinAD) {
+                                    $True {'Yes'}
+                                    $false {'No'}
+                                    default {'Unknown'}
+                                }
+                            }
+                            $DCHPInfo += [pscustomobject]$inobj
+                        } catch {
+                            Write-PScriboMessage -IsWarning "$($_.Exception.Message) (DHCP Item)"
+                        }
+                    }
+
+                    $TableParams = @{
+                        Name = "DHCP Infrastructure - $($ForestInfo.toUpper())"
+                        List = $false
+                        ColumnWidths = 50, 50
+                    }
+                    if ($Report.ShowTableCaptions) {
+                        $TableParams['Caption'] = "- $($TableParams.Name)"
+                    }
+                    $DCHPInfo | Sort-Object -Property 'Server Name' | Table @TableParams
+                }
+            } else {
+                Write-PScriboMessage -IsWarning "No DHCP Infrastructure information found in $($ForestInfo.toUpper()), disabling the section."
+            }
+        } catch {
+            Write-PScriboMessage -IsWarning "$($_.Exception.Message) (DHCP Table)"
+        }
+    }
+
+    end {}
+
+}

--- a/Src/Private/Get-AbrForestSection.ps1
+++ b/Src/Private/Get-AbrForestSection.ps1
@@ -53,6 +53,11 @@ function Get-AbrForestSection {
                         } catch {
                             Write-PScriboMessage -IsWarning $_.Exception.Message
                         }
+                        try {
+                            Get-AbrDHCPinAD
+                        } catch {
+                            Write-PScriboMessage -IsWarning $_.Exception.Message
+                        }
                     }
                 } catch {
                     Write-PScriboMessage -IsWarning "Error: Unable to retreive Forest: $ForestInfo information."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

### [0.8.2] - 2024-06-15

#### Added

- Add Diagrammer.Core to the module RequiredModules list

#### Changed

- Improve the code to better handle errors
- Update the Eomm/why-don-t-you-tweet action to v2.0.0
- Increase the default InfoLevel for the Forest and Domain section (InfoLevel 2)
- Enable DNS section by default (InfoLevel 1)

#### Fixed

- Fix [#160](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/160)
- Fix [#168](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/168)
- Fix [#171](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/171)
- Fix [#172](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/172)
- Fix [#174](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/174)
- Fix [#176](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/176)
- Fix [#178](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/178)
- Fix [#180](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/180)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- HomeLab

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://www.asbuiltreport.com/about/contributing/#use-a-consistent-coding-style) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [contributing](https://www.asbuiltreport.com/about/contributing/) documentation.
