### PR TITLE
v0.9.10 Public release

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -37,29 +37,29 @@ jobs:
         shell: pwsh
         run: |
           Publish-Module -Path ./ -NuGetApiKey ${{ secrets.PSGALLERY_API_KEY }} -Verbose
-  tweet:
-    needs: publish-to-gallery
-    runs-on: ubuntu-latest
-    steps:
-      - uses: Eomm/why-don-t-you-tweet@v2
-        # We don't want to tweet if the repository is not a public one
-        if: ${{ !github.event.repository.private }}
-        with:
-          # GitHub event payload
-          # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#release
-          tweet-message: "[New Release] ${{ github.event.repository.name }} ${{ github.event.release.tag_name }}! Check out what's new! ${{ github.event.release.html_url }} #Microsoft #ActiveDirectory #AsBuiltReport #PowerShell #MicrosoftMVP #MVPBuzz #cybersecurity #infosec"
-        env:
-          TWITTER_CONSUMER_API_KEY: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
-          TWITTER_CONSUMER_API_SECRET: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
-          TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
-  bsky-post:
-    needs: publish-to-gallery
-    runs-on: ubuntu-latest
-    steps:
-      - uses: zentered/bluesky-post-action@v0.3.0
-        with:
-          post: "[New Release] ${{ github.event.repository.name }} ${{ github.event.release.tag_name }}! Check out what's new! ${{ github.event.release.html_url }} #Microsoft #ActiveDirectory #AsBuiltReport #PowerShell #MicrosoftMVP #MVPBuzz #cybersecurity #infosec"
-        env:
-          BSKY_IDENTIFIER: ${{ secrets.BSKY_IDENTIFIER }}
-          BSKY_PASSWORD: ${{ secrets.BSKY_PASSWORD }}
+  # tweet:
+  #   needs: publish-to-gallery
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: Eomm/why-don-t-you-tweet@v2
+  #       # We don't want to tweet if the repository is not a public one
+  #       if: ${{ !github.event.repository.private }}
+  #       with:
+  #         # GitHub event payload
+  #         # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#release
+  #         tweet-message: "[New Release] ${{ github.event.repository.name }} ${{ github.event.release.tag_name }}! Check out what's new! ${{ github.event.release.html_url }} #Microsoft #ActiveDirectory #AsBuiltReport #PowerShell #MicrosoftMVP #MVPBuzz #cybersecurity #infosec"
+  #       env:
+  #         TWITTER_CONSUMER_API_KEY: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
+  #         TWITTER_CONSUMER_API_SECRET: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
+  #         TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+  #         TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+  # bsky-post:
+  #   needs: publish-to-gallery
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: zentered/bluesky-post-action@v0.3.0
+  #       with:
+  #         post: "[New Release] ${{ github.event.repository.name }} ${{ github.event.release.tag_name }}! Check out what's new! ${{ github.event.release.html_url }} #Microsoft #ActiveDirectory #AsBuiltReport #PowerShell #MicrosoftMVP #MVPBuzz #cybersecurity #infosec"
+  #       env:
+  #         BSKY_IDENTIFIER: ${{ secrets.BSKY_IDENTIFIER }}
+  #         BSKY_PASSWORD: ${{ secrets.BSKY_PASSWORD }}

--- a/AsBuiltReport.Microsoft.AD.psd1
+++ b/AsBuiltReport.Microsoft.AD.psd1
@@ -12,7 +12,7 @@
     RootModule = 'AsBuiltReport.Microsoft.AD.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.9.9'
+    ModuleVersion = '0.9.10'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -27,7 +27,7 @@
     # CompanyName = 'Unknown'
 
     # Copyright statement for this module
-    Copyright = '(c) 2025 Jonathan Colon. All rights reserved.'
+    Copyright = '(c) 2026 Jonathan Colon. All rights reserved.'
 
     # Description of the functionality provided by this module
     Description = 'A PowerShell module to generate an as built report on the configuration of Microsoft AD.'
@@ -66,7 +66,7 @@
         },
         @{
             ModuleName = 'Diagrammer.Core';
-            ModuleVersion = '0.2.36.1'
+            ModuleVersion = '0.2.37'
         }
     )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### This project is community maintained and has no sponsorship from Microsoft, its employees or any of its affiliates.
 
+## [0.9.10] - 2026-01-26
+
+### :arrows_clockwise: Changed
+
+- Update module version to `0.9.10`
+- Update Diagrammer.Core module to `0.2.37`
+
+### :bug: Fixed
+
+- Fix the computer/user stats table so that it displays the correct values
+- Fix the size of the diagram, which does not respect the size of the document border
+- Fix domain section not discovering information from root domain
+- Fix the trust diagram, only displaying forest wide trust and not trusts from child domain
+
 ## [0.9.9] - 2026-01-16
 
-### Added
+### :toolbox: Added
 
 - Add disclaimer warning to README.md about report usage and liability
 - Add option to control the ping count of the DC Test-Connection cmdlet
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Improve error logging and handling for initial Forest and Domain discovery process
 - Update module version to `0.9.9`
@@ -25,26 +39,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated the dcdiag section to include a 60-second timeout. This keeps the report from freezing if the diagnostic check takes too long.
 
 
-### Fixed
+### :bug: Fixed
 
 - Fix cannot index into a null array error when generating Trusts diagrams for domains with no trusts defined
 - Fix Trusts diagram generation when multiple domains are present in the report
 - Fix issue with Global:Report variable
 
-### Removed
+### :x: Removed
 
 - Remove Diagrammer.Microsoft.Ad module dependency
 - Remove Image preview message from diagrams sections
 
 ## [0.9.8] - 2025-12-09
 
-### Added
+### :toolbox: Added
 
 - Add support for PowerShell 7
 - Add function to Invoke-Command with timeout support (Jobs Scheduler)
 - Add FileName parameter to Get-AbrDiagrammer to allow custom file names for diagram outputs
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Update module version to 0.9.8
 - Upgrade Diagrammer.Core module to version `0.2.35`
@@ -56,7 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve Get-RequiredFeatures function to better handle feature retrieval and error handling
 - Improve timeout warning message in Invoke-CommandWithTimeout
 
-### Fixed
+### :bug: Fixed
 
 - Fix HealthCheck in Get-AbrADDomainLastBackup script to correctly evaluate the 'Last Backup in Days' property as an integer
 - Fix 'Orphaned GPO' section displaying data when no orphaned GPOs are found in Get-AbrADGPO script
@@ -64,7 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.7] - 2025-11-14
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Update module version to 0.9.7
 - Upgrade Diagrammer.Core module to version `0.2.34`.
@@ -72,17 +86,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade zentered/bluesky-post-action to v0.3.0
 - Improve section paragraphs in multiple scripts for better clarity and understanding.
 
-### Fixed
+### :bug: Fixed
 
 - Fix HealthChack in Get-AbrADDomainLastBackup script to correctly evaluate the 'Last Backup in Days' property as an integer.
 
 ## [0.9.6] - 2025-07-23
 
-### Added
+### :toolbox: Added
 
 - Add System Center Configuration Manager (MEM) information
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Update module version to 0.9.6
 - Enhance execution time tracking in Get-AbrADDomainObject function
@@ -94,18 +108,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refine section descriptions across multiple PowerShell scripts for clarity and consistency.
 - Updated wording to enhance readability and provide more precise information about the content of each section to better reflect the information presented.
 
-### Fixed
+### :bug: Fixed
 
 - Fix property names in software object initialization for consistency and clarity (Installed Software section)
 - Fix [#210](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/210)
 
 ## [0.9.5] - 2025-05-10
 
-### Added
+### :toolbox: Added
 
 - Add Show-AbrDebugExecutionTime function to track execution time of operations
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Update PSScriptAnalyzer settings for enhanced code quality checks.
 - Bump module version to `0.9.5`.
@@ -140,19 +154,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Get-AbrPKISection.ps1
 - Removed unnecessary comments and cleaned up code for better readability.
 
-### Fixed
+### :bug: Fixed
 
 - Fix message in Get-AbrDiagrammer function to correctly reference DiagramType
 
 ## [0.9.4] - 2025-04-28
 
-### Added
+### :toolbox: Added
 
 - Add a new section in Get-AbrDomainSection to retrieve and sort DCs while excluding specified ones, enhancing the overall structure and clarity of the script.
 - Add diagram options to configuration file for various sections.
 - Introduced Get-AbrDiagrammer function to generate diagrams in multiple formats.
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Increase AsBuiltReport.Core to v1.4.3
 - Increase Diagrammer.Core minimum requirement
@@ -175,30 +189,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Get-ValidCIMSession
   - Get-ValidPSSession
 
-### Fixed
+### :bug: Fixed
 
 - Fix issue with WinRM connection setup in Domain Controller section
 
-### Removed
+### :x: Removed
 
 - Remove DCDiag section as it is not functioning properly
 
 ## [0.9.3] - 2025-02-21
 
-### Added
+### :toolbox: Added
 
 - Add Site Inventory diagram to the Replication section
 - Add Certificate Authority diagram
 
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Move Circular Group Membership section to $InfoLevel.Domain level 4
 - Increase AsBuiltReport.Core to v1.4.2
 - Increase Diagrammer.Core minimum requirement
 - Increase Diagrammer.Microsoft.AD minumum requirement
 
-### Fixed
+### :bug: Fixed
 
 - Fix error message during DC discovery and WinRM connection
 - Fix Get-WinADLastBackup cmdlet not returning AD partitions when the report generation machine is not part of the same domain or forest as the target domain controller
@@ -208,49 +222,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.2] - 2025-01-14
 
-### Added
+### :toolbox: Added
 
 - Add support for WinRM over SSL
 - Add option to set the WinRM tcp port used for PSSession connection setup
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Increase Diagrammer.Core minimum requirement
 - Increase AsBuiltReport.Core to v1.4.1
 - Improve DC selection logic
 - Improve HealthCheck best practice recommendations (@Copilot)
 
-### Fixed
+### :bug: Fixed
 
 - Fix [#190](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/190)
 - Fix [#191](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/191)
 - Fix ConvertTo-HashToYN cmdlet not generating an ordereddictionary output
 
-### Removed
+### :x: Removed
 
 - Remove dependabot action (Not supported in Abr Organization)
 
 ## [0.9.1] - 2024-11-15
 
-### Added
+### :toolbox: Added
 
 - Improve detection of empty fields in tables
 - Improve detection of true/false elements in tables
 - Update GitHub release workflow to add post to Bluesky social platform
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Increase Diagrammer.Core minimum requirement
 - Increase Diagrammer.Microsoft.AD minumum requirement
 
 ## [0.9.0] - 2024-10-13
 
-### Added
+### :toolbox: Added
 
 - Initial support for Server 2025
 - Add Dependabot action
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Increase Diagrammer.Core minimum requirement
 - Increase Diagrammer.Microsoft.AD minumum requirement
@@ -258,7 +272,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.2] - 2024-06-15
 
-### Added
+### :toolbox: Added
 
 - Add Diagrammer.Core to the module RequiredModules list
 - Add Health Check to detect circular group membership
@@ -268,14 +282,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Health Check to find Computers with password-not-required attribute set
 - Add basic DHCP Infrastructure information
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Improve the code to better handle errors
 - Update the Eomm/why-don-t-you-tweet action to v2.0.0
 - Increase the default InfoLevel for the Forest and Domain section (InfoLevel 2)
 - Enable DNS section by default (InfoLevel 1)
 
-### Fixed
+### :bug: Fixed
 
 - Fix [#160](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/160)
 - Fix [#168](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/168)
@@ -288,13 +302,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.1] - 2024-05-16
 
-### Added
+### :toolbox: Added
 
 - Site Topology diagram
 - Domain and Trust diagram
 - Foreign Security Principals section
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Remove Graphviz install check code
 - Code cleanup
@@ -304,7 +318,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change charts default font to Segoe Ui
 - Improved Forest diagram
 
-### Fixed
+### :bug: Fixed
 
 - Improve error handling on Forest diagram section
 - Fix issues with Diagrammer.Microsoft.AD module
@@ -315,20 +329,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix [#151](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/151)
 - Fix [#150](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/150)
 
-### Removed
+### :x: Removed
 
 - Removed EnableDiagrams option
 - Removed EnableCharts option
 
 ## [0.8.0] - 2024-01-24
 
-### Added
+### :toolbox: Added
 
 - Added initial diagram support:
   - Forest Diagram
 - Added disclaimer section if the EnableHealthCheck option is used.
 
-### Fixed
+### :bug: Fixed
 
 - Fix [#137](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/137)
 - Fix [#138](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/138)
@@ -336,14 +350,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.15] - 2023-10-03
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Improved verbose logging
 - Improved PKI Section
 
 ## [0.7.14] - 2023-07-25
 
-### Fixed
+### :bug: Fixed
 
 - Resolve [#113](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/113)
 - Resolve [#116](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/116)
@@ -360,18 +374,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.13] - 2023-06-22
 
-### Added
+### :toolbox: Added
 
 - Added Option "Include.Domains" to allow only a list of Active Directory Domain to document
   - Include Domains in AD services
   - Include Domains in DNS services
 - Added Site Connection Objects section
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Major improvements to health check recommendations
 
-### Fixed
+### :bug: Fixed
 
 - Fix HealthCheck sections not working after v0.7.12
 - Fix [#84](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/84)
@@ -393,18 +407,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.12] - 2023-05-23
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Removed DHCP section (migrated to AsBuiltReport.Microsoft.DHCP)
 - Disabled DNS & CA section by default
 
 ## [0.7.11] - 2023-03-09
 
-### Added
+### :toolbox: Added
 
 - Added section for Local Administrator Password Solution.
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Improved bug and feature request templates
 - Changed default logo from Microsoft to the AsBuiltReport logo due to licensing requirements
@@ -417,14 +431,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Sites Replication Connection
   - Domain and Trusts
 
-### Fixed
+### :bug: Fixed
 
 - [#81](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/81)
-### Added
+### :toolbox: Added
 
 - Added section for Local Administrator Password Solution.
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Improved bug and feature request templates
 - Changed default logo from Microsoft to the AsBuiltReport logo due to licensing requirements
@@ -437,30 +451,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Sites Replication Connection
   - Domain and Trusts
 
-### Fixed
+### :bug: Fixed
 
 - [#81](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/81)
 
 ## [0.7.10] - 2022-10-28
 
-### Fixed
+### :bug: Fixed
 
 - Fix issue [#83](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/83) (Error running report if multiple version are installed together)
 
 ## [0.7.9] - 2022-10-09
 
-### Added
+### :toolbox: Added
 
 - Added charts to the Domain object count sub-sections
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Split the Domain object count section.
   - Computers Object count
   - User object count
   - Domain Controller count
 
-### Fixed
+### :bug: Fixed
 
 - close [#69](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/69)
 - close [#74](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/74)
@@ -471,11 +485,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.8] - 2022-10-04
 
-### Added
+### :toolbox: Added
 
 - Added Simple Chart support
 
-### Fixed
+### :bug: Fixed
 
 - close [#67](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/67)
 - close [#68](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/68)
@@ -483,15 +497,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.7] - 2022-09-07
 
-### Added
+### :toolbox: Added
 
 - Add table to show the pending/missing Windows updates (Health Check)
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Improve domain controller dcdiag table
 
-### Fixed
+### :bug: Fixed
 
 - close [#57](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/57)
 - close [#59](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/59)
@@ -501,17 +515,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.6] - 2022-09-04
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Improve report table of content
 
-### Fixed
+### :bug: Fixed
 
 - close [#52](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/52)
 
 ## [0.7.5] - 2022-08-06
 
-### Added
+### :toolbox: Added
 
 - Added SYSVOL/NETLOGON folder content status
   - Added Health Check for malicious/unessential file extensions
@@ -519,25 +533,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added Health Check for SRV Records Status
 - Added Health Check for Unsupported Operating System findings in the Active Directory Domain
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Allowed the Forest Root Domain to be the fisrt Domain in the report
 - Improved Sites Replication (repadmin) section
 
 ## [0.7.4] - 2022-07-29
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Access well known groups via SID to include international names and expand them to localized group names.
 - Removed PSSharedGoods/PSWriteColor module dependency
 
-### Fixed
+### :bug: Fixed
 
 - Fixes [#42](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/42)
 
 ## [0.7.3] - 2022-05-13
 
-### Added
+### :toolbox: Added
 
 - Improved validation of module dependencies
 - Added Option "Exclude.Domains" to allow Active Directory Domain exclusions
@@ -552,7 +566,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.2] - 2022-04-25
 
-### Added
+### :toolbox: Added
 
 - Improved AD user/group object stats
   - Added Privileged Group count information
@@ -561,24 +575,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added RID Pool Issued/Available information
 - Added Domain,Site and Global Catalog count information
 
-### Fixed
+### :bug: Fixed
 
 - Fix report module dependencies. Closes #35
 
 ## [0.7.1] - 2022-03-14
 
-### Added
+### :toolbox: Added
 
 - Added Kerberos Audit section.
   - Added Health Check condition and explanatione
 
-### Fixed
+### :bug: Fixed
 
 - Fix release workflows to include PSSharedGoods module.
 
 ## [0.7.0] - 2022-03-14
 
-### Added
+### :toolbox: Added
 
 - Implemented health check explanations.
 - Added Health Check:
@@ -588,19 +602,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Search for Account Security Issues.
 - Added Naming Context Backup information.
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Improve Health Check content.
 - Added enabled status on Forest Optional Features section.
 
-### Fixed
+### :bug: Fixed
 
 - Fix DNS section issues.
 - Sort "Organizational Unit" section by path. Closes #27
 
 ## [0.6.3] - 2022-01-30
 
-### Changed
+### :arrows_clockwise: Changed
 
 - More Code refactoring to improve performance.
 - Migrated DNS/DHCP Server section to use CIM sessions.
@@ -608,14 +622,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added variable to control CIM/PSRemote authentication method (PSDefaultAuthentication)
 - Changed report main text color.
 
-### Fixed
+### :bug: Fixed
 
 - Fix for more table caption error messages.
 - Fix section heading hierarchy
 
 ## [0.6.2] - 2022-01-24
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Code refactoring to improve performance.
 - Implement more try/catch to better handle terminating errors.
@@ -623,25 +637,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve Sections title text.
 - Improve table sorting.
 
-### Fixed
+### :bug: Fixed
 
 - Fix for table caption error messages.
 
 ## [0.6.1] - 2021-12-07
 
-### Added
+### :toolbox: Added
 
 - Added Sample HTML Report Link to README file.
 - Added DHCP/DNS Powershell module installation instructions. Closes #18
 
-### Fixed
+### :bug: Fixed
 
 - Improved the code to better detect whether a DHCP/CA infrastructure is in place. Closes #17
 - Fix missing comma in JSON File. Closes #16
 
 ## [0.6.0] - 2021-12-02
 
-### Added
+### :toolbox: Added
 
 - Added more CA Sections (Need More Testing)
   - Added CRL Repository
@@ -651,35 +665,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added Key Recovery Agent Information
   - Added Cryptography Configuration Information
 
-### Changed
+### :arrows_clockwise: Changed
 
 - The spelling of the section title has been revised.
 - Enabled CA InfoLevels Option.
 
 ## [0.5.0] - 2021-10-29
 
-### Added
+### :toolbox: Added
 
 - Added ShowDefinitionInfo Option (Allows the user to choose whether to enable AD term explanations.)
 - Explanation of the ShowDefinitionInfo option has been added to the ReadMe file.
 - Added Dynamic DNS Credentials Health Check.
 - Added updated HTML Sample Report.
 
-### Changed
+### :arrows_clockwise: Changed
 
 - The spelling of the section title has been revised.
 - Moved DNS Zone section to InfoLevel 2.
 - Moved Role and Feature section to InfoLevel 3.
 - Removed Unused InfoLevels (CA & Security).
 
-### Fixed
+### :bug: Fixed
 
 - Fix try/catch error messages (globally)
 - Fix try/catch logic on the DNS Section (Fix [#11](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/11))
 
 ## [0.4.0] - 2021-10-08
 
-### Added
+### :toolbox: Added
 
 - Added Installed Roles and Features to the DC Section.
 - Added Fined Grained Password Policies to the Domain Section (fix issue #6).
@@ -700,7 +714,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added more DHCP IPv4/IPv6 Health Checks.
 - Added DNS Conditional Forwarder to DNS Section (fix issue #6).
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Added more Heading definitions.
 - Disable Certificate Authority until is Completed.
@@ -711,7 +725,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added DHCP InfoLevel 2 Option.
 - Updated Sample Report
 
-### Fixed
+### :bug: Fixed
 
 - Fix more PSSession exhaustion.
 - Remove the PSPKI module from ReadMe file.
@@ -720,7 +734,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2021-09-26
 
-### Added
+### :toolbox: Added
 
 - Added Active Directory DHCP summary information.
   - Added DHCP Database information.
@@ -736,13 +750,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added DHCP Scope Interface Binding information.
   - Added DHCP health check.
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Added more Heading definitions.
 - Added funtion to convert from subnetmask to dotted notation.
 - Added a function to convert empty culumns to "-" (less switch cases).
 
-### Fixed
+### :bug: Fixed
 
 - Fix for PSSession exhaustion.
 - Fix for DNS Zone Delegation IPaddress variable
@@ -754,7 +768,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2021-09-10
 
-### Added
+### :toolbox: Added
 
 - Added Active Directory DNS summary information.
   - Added DNS Forwarder summary information.
@@ -765,14 +779,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Added DNS Zone Delegation configuration information.
   - Added more health checks.
 
-### Changed
+### :arrows_clockwise: Changed
 
 - Improved per Domain configuration information.
 - Improved per Domain Controller configuration information.
 - Introduced the ability to use a shared PSsession.
 - Merged the functions used within the reports into a single file (SharedUtilsFunctions).
 
-### Fixed
+### :bug: Fixed
 
 - Enhanced the logic of detecting a unavailable Domain or DC.
 - Enhanced verbose/degug logging.
@@ -780,7 +794,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2021-08-10
 
-### Added
+### :toolbox: Added
 
 - Added Active Directory Forest summary information.
   - Added Forest Optional Features Summary.

--- a/Src/Private/Get-AbrADCaInfo.ps1
+++ b/Src/Private/Get-AbrADCaInfo.ps1
@@ -26,9 +26,9 @@ function Get-AbrADCAInfo {
             $ForestObj = $ADSystem
 
             $ConfigNCDN = $ForestObj.PartitionsContainer.Split(',') | Select-Object -Skip 1
-            $rootCAs = Get-ADObjectSearch -DN "CN=Certification Authorities,CN=Public Key Services,CN=Services,$($ConfigNCDN -join ',')" -Filter { objectClass -eq 'certificationAuthority' } -Properties '*' -SelectPrty 'DistinguishedName', 'Name', 'cACertificate' -Session $TempPssSession
+            $rootCAs = Get-ADObjectSearch -DN "CN=Certification Authorities,CN=Public Key Services,CN=Services,$($ConfigNCDN -join ',')" -Filter { objectClass -eq 'certificationAuthority' } -Properties '*' -SelectPrty 'DistinguishedName', 'Name', 'cACertificate' -Session $DiagramTempPssSession
 
-            $subordinateCAs = Get-ADObjectSearch -DN "CN=Enrollment Services,CN=Public Key Services,CN=Services,$($ConfigNCDN -join ',')" -Filter { objectClass -eq 'pKIEnrollmentService' } -Properties '*' -SelectPrty 'dNSHostName', 'Name', 'cACertificate' -Session $TempPssSession
+            $subordinateCAs = Get-ADObjectSearch -DN "CN=Enrollment Services,CN=Public Key Services,CN=Services,$($ConfigNCDN -join ',')" -Filter { objectClass -eq 'pKIEnrollmentService' } -Properties '*' -SelectPrty 'dNSHostName', 'Name', 'cACertificate' -Session $DiagramTempPssSession
 
             $CAInfo = @()
             if ($rootCAs) {

--- a/Src/Private/Get-AbrADDomainObject.ps1
+++ b/Src/Private/Get-AbrADDomainObject.ps1
@@ -5,7 +5,7 @@ function Get-AbrADDomainObject {
     .DESCRIPTION
 
     .NOTES
-        Version:        0.9.9
+        Version:        0.9.10
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -156,25 +156,30 @@ function Get-AbrADDomainObject {
                                 }
                                 $inObj = [ordered] @{
                                     'Category' = $Category
-                                    'Enabled' = ($Values.Enabled -eq $True | Measure-Object).Count
-                                    'Enabled %' = switch ($Users.Count) {
-                                        0 { '0' }
-                                        $Null { '0' }
+                                    'Enabled' = switch ([string]::IsNullOrEmpty($Values.Enabled)) {
+                                        $true { '0' }
+                                        default { ($Values.Enabled -eq $True | Measure-Object).Count }
+                                    }
+                                    'Enabled %' = switch ([string]::IsNullOrEmpty($Users.Count)) {
+                                        $true { '0' }
                                         default { [math]::Round((($Values.Enabled -eq $True | Measure-Object).Count / $Users.Count * 100), 2) }
                                     }
-                                    'Disabled' = ($Values.Enabled -eq $False | Measure-Object).Count
-                                    'Disabled %' = switch ($Users.Count) {
-                                        0 { '0' }
-                                        $Null { '0' }
+                                    'Disabled' = switch ([string]::IsNullOrEmpty($Values.Enabled)) {
+                                        $true { '0' }
+                                        default { ($Values.Enabled -eq $False | Measure-Object).Count }
+                                    }
+                                    'Disabled %' = switch ([string]::IsNullOrEmpty($Users.Count)) {
+                                        $true { '0' }
                                         default { [math]::Round((($Values.Enabled -eq $False | Measure-Object).Count / $Users.Count * 100), 2) }
                                     }
-                                    'Total' = ($Values | Measure-Object).Count
-                                    'Total %' = switch ($Users.Count) {
-                                        0 { '0' }
-                                        $Null { '0' }
+                                    'Total' = switch ([string]::IsNullOrEmpty($Values)) {
+                                        $true { '0' }
+                                        default { ($Values | Measure-Object).Count }
+                                    }
+                                    'Total %' = switch ([string]::IsNullOrEmpty($Users.Count)) {
+                                        $true { '0' }
                                         default { [math]::Round((($Values | Measure-Object).Count / $Users.Count * 100), 2) }
                                     }
-
                                 }
                                 $OutObj.Add([pscustomobject](ConvertTo-HashToYN $inObj)) | Out-Null
                             } catch {
@@ -774,25 +779,30 @@ function Get-AbrADDomainObject {
                                 }
                                 $inObj = [ordered] @{
                                     'Category' = $Category
-                                    'Enabled' = ($Values.Enabled -eq $True | Measure-Object).Count
-                                    'Enabled %' = switch ($Computers.Count) {
-                                        0 { '0' }
-                                        $Null { '0' }
-                                        default { [math]::Round((($Values.Enabled -eq $True | Measure-Object).Count / $Computers.Count * 100), 2) }
+                                    'Enabled' = switch ([string]::IsNullOrEmpty($Values.Enabled)) {
+                                        $true { '0' }
+                                        default { ($Values.Enabled -eq $True | Measure-Object).Count }
                                     }
-                                    'Disabled' = ($Values.Enabled -eq $False | Measure-Object).Count
-                                    'Disabled %' = switch ($Computers.Count) {
-                                        0 { '0' }
-                                        $Null { '0' }
-                                        default { [math]::Round((($Values.Enabled -eq $False | Measure-Object).Count / $Computers.Count * 100), 2) }
+                                    'Enabled %' = switch ([string]::IsNullOrEmpty($Users.Count)) {
+                                        $true { '0' }
+                                        default { [math]::Round((($Values.Enabled -eq $True | Measure-Object).Count / $Users.Count * 100), 2) }
                                     }
-                                    'Total' = ($Values | Measure-Object).Count
-                                    'Total %' = switch ($Computers.Count) {
-                                        0 { '0' }
-                                        $Null { '0' }
-                                        default { [math]::Round((($Values | Measure-Object).Count / $Computers.Count * 100), 2) }
+                                    'Disabled' = switch ([string]::IsNullOrEmpty($Values.Enabled)) {
+                                        $true { '0' }
+                                        default { ($Values.Enabled -eq $False | Measure-Object).Count }
                                     }
-
+                                    'Disabled %' = switch ([string]::IsNullOrEmpty($Users.Count)) {
+                                        $true { '0' }
+                                        default { [math]::Round((($Values.Enabled -eq $False | Measure-Object).Count / $Users.Count * 100), 2) }
+                                    }
+                                    'Total' = switch ([string]::IsNullOrEmpty($Values)) {
+                                        $true { '0' }
+                                        default { ($Values | Measure-Object).Count }
+                                    }
+                                    'Total %' = switch ([string]::IsNullOrEmpty($Users.Count)) {
+                                        $true { '0' }
+                                        default { [math]::Round((($Values | Measure-Object).Count / $Users.Count * 100), 2) }
+                                    }
                                 }
                                 $OutObj.Add([pscustomobject](ConvertTo-HashToYN $inObj)) | Out-Null
                             } catch {

--- a/Src/Private/Get-AbrADForest.ps1
+++ b/Src/Private/Get-AbrADForest.ps1
@@ -116,9 +116,9 @@ function Get-AbrADForest {
                         }
 
                         if ($Graph) {
-                            if ((Get-DiaImagePercent -GraphObj $Graph).Width -gt 600) { $ImagePrty = 20 } else { $ImagePrty = 40 }
-                            Section -Style Heading3 'Forest Diagram.' {
-                                Image -Base64 $Graph -Text 'Forest Diagram' -Percent $ImagePrty -Align Center
+                            $BestAspectRatio = Get-DiaBestImageAspectRatio -GraphObj $Graph -MaxWidth 600
+                            Section -Style Heading3 'Forest Diagram' {
+                                Image -Base64 $Graph -Text 'Forest Diagram' -Width $BestAspectRatio.Width -Height $BestAspectRatio.Height -Align Center
                             }
                             BlankLine -Count 2
                         }
@@ -223,9 +223,9 @@ function Get-AbrADForest {
                         }
 
                         if ($Graph) {
-                            if ((Get-DiaImagePercent -GraphObj $Graph).Width -gt 600) { $ImagePrty = 20 } else { $ImagePrty = 40 }
-                            Section -Style Heading4 'Certificate Authority Diagram.' {
-                                Image -Base64 $Graph -Text 'Certificate Authority Diagram' -Percent $ImagePrty -Align Center
+                            $BestAspectRatio = Get-DiaBestImageAspectRatio -GraphObj $Graph -MaxWidth 600
+                            Section -Style Heading4 'Certificate Authority Diagram' {
+                                Image -Base64 $Graph -Text 'Certificate Authority Diagram' -Width $BestAspectRatio.Width -Height $BestAspectRatio.Height -Align Center
                             }
                             BlankLine -Count 2
                         }

--- a/Src/Private/Get-AbrADForestInfo.ps1
+++ b/Src/Private/Get-AbrADForestInfo.ps1
@@ -57,13 +57,13 @@ function Get-AbrADForestInfo {
                 foreach ($Childs in $ParentChildObj | Sort-Object) {
                     foreach ($ChildDomain in $Childs.Children) {
                         $ChildDomainsInfo = try {
-                            Invoke-CommandWithTimeout -Session $TempPssSession -ScriptBlock { Get-ADDomain -Identity $using:ChildDomain }
+                            Invoke-CommandWithTimeout -Session $DiagramTempPssSession -ScriptBlock { Get-ADDomain -Identity $using:ChildDomain }
                         } catch {
                             Out-Null
                         }
 
                         $RootDomainsInfo = try {
-                            Invoke-CommandWithTimeout -Session $TempPssSession -ScriptBlock { Get-ADDomain -Identity ($using:ForestObj).RootDomain }
+                            Invoke-CommandWithTimeout -Session $DiagramTempPssSession -ScriptBlock { Get-ADDomain -Identity ($using:ForestObj).RootDomain }
                         } catch {
                             Out-Null
                         }
@@ -144,7 +144,7 @@ function Get-AbrADForestInfo {
                 }
             } else {
                 $RootDomainsInfo = try {
-                    Invoke-CommandWithTimeout -Session $TempPssSession -ScriptBlock { Get-ADDomain -Identity ($using:ForestObj).RootDomain }
+                    Invoke-CommandWithTimeout -Session $DiagramTempPssSession -ScriptBlock { Get-ADDomain -Identity ($using:ForestObj).RootDomain }
                 } catch {
                     Out-Null
                 }

--- a/Src/Private/Get-AbrADSite.ps1
+++ b/Src/Private/Get-AbrADSite.ps1
@@ -40,9 +40,9 @@ function Get-AbrADSite {
                             }
 
                             if ($Graph) {
-                                if ((Get-DiaImagePercent -GraphObj $Graph).Width -gt 600) { $ImagePrty = 20 } else { $ImagePrty = 40 }
-                                Section -Style Heading4 'Site Inventory Diagram.' {
-                                    Image -Base64 $Graph -Text 'Site Inventory Diagram' -Percent $ImagePrty -Align Center
+                                $BestAspectRatio = Get-DiaBestImageAspectRatio -GraphObj $Graph -MaxWidth 600
+                                Section -Style Heading4 'Site Inventory Diagram' {
+                                    Image -Base64 $Graph -Text 'Site Inventory Diagram' -Width $BestAspectRatio.Width -Height $BestAspectRatio.Height -Align Center
                                 }
                                 BlankLine -Count 2
                             }
@@ -334,9 +334,9 @@ function Get-AbrADSite {
                             }
 
                             if ($Graph) {
-                                if ((Get-DiaImagePercent -GraphObj $Graph).Width -gt 600) { $ImagePrty = 20 } else { $ImagePrty = 40 }
-                                Section -Style Heading4 'Site Topology Diagram.' {
-                                    Image -Base64 $Graph -Text 'Site Topology Diagram' -Percent $ImagePrty -Align Center
+                                $BestAspectRatio = Get-DiaBestImageAspectRatio -GraphObj $Graph -MaxWidth 600
+                                Section -Style Heading4 'Site Topology Diagram' {
+                                    Image -Base64 $Graph -Text 'Site Topology Diagram' -Width $BestAspectRatio.Width -Height $BestAspectRatio.Height -Align Center
                                 }
                                 BlankLine -Count 2
                             }

--- a/Src/Private/Get-AbrADSitesInfo.ps1
+++ b/Src/Private/Get-AbrADSitesInfo.ps1
@@ -23,7 +23,7 @@ function Get-AbrADSitesInfo {
     process {
         Write-Verbose -Message ($reportTranslate.NewADDiagram.buildingSites -f $($ForestRoot))
         try {
-            $Sites = Invoke-CommandWithTimeout -Session $TempPssSession -ScriptBlock { [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest().Sites | Select-Object Name, @{l = 'SitesLink'; e = { $_.sitelinks } } }
+            $Sites = Invoke-CommandWithTimeout -Session $DiagramTempPssSession -ScriptBlock { [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest().Sites | Select-Object Name, @{l = 'SitesLink'; e = { $_.sitelinks } } }
 
             $SitesInfo = @()
             if ($Sites) {
@@ -32,10 +32,10 @@ function Get-AbrADSitesInfo {
                         'Name' = $SitesLink.Name
                         'SiteLink' = & {
                             foreach ($Link in $SitesLink.SitesLink.Name) {
-                                $SitesLinkInfo = Invoke-CommandWithTimeout -Session $TempPssSession -ScriptBlock { Get-ADReplicationSiteLink -Identity $using:Link -Properties * }
+                                $SitesLinkInfo = Invoke-CommandWithTimeout -Session $DiagramTempPssSession -ScriptBlock { Get-ADReplicationSiteLink -Identity $using:Link -Properties * }
                                 @{
                                     'Name' = $Link
-                                    'Sites' = $SitesLinkInfo.SitesIncluded | ForEach-Object { ConvertTo-ADObjectName -Session $TempPssSession -DN $_ -DC $System }
+                                    'Sites' = $SitesLinkInfo.SitesIncluded | ForEach-Object { ConvertTo-ADObjectName -Session $DiagramTempPssSession -DN $_ -DC $System }
                                     'AditionalInfo' = [ordered]@{
                                         $reportTranslate.NewADDiagram.siteLinkName = $Link
                                         $reportTranslate.NewADDiagram.siteLinkCost = $SitesLinkInfo.Cost

--- a/Src/Private/Get-AbrADSitesInventoryInfo.ps1
+++ b/Src/Private/Get-AbrADSitesInventoryInfo.ps1
@@ -23,7 +23,7 @@ function Get-AbrADSitesInventoryInfo {
     process {
         Write-Verbose -Message ($reportTranslate.NewADDiagram.buildingSites -f $($ForestRoot))
         try {
-            $Sites = Invoke-CommandWithTimeout -Session $TempPssSession -ScriptBlock { Get-ADReplicationSite -Filter * -Properties * }
+            $Sites = Invoke-CommandWithTimeout -Session $DiagramTempPssSession -ScriptBlock { Get-ADReplicationSite -Filter * -Properties * }
 
             $SitesInfo = @()
             if ($Sites) {
@@ -36,7 +36,7 @@ function Get-AbrADSitesInventoryInfo {
                             $SubnetArray = @()
                             $Subnets = $Site.Subnets
                             foreach ($Object in $Subnets) {
-                                $SubnetName = Invoke-CommandWithTimeout -Session $TempPssSession -ScriptBlock { Get-ADReplicationSubnet $using:Object }
+                                $SubnetName = Invoke-CommandWithTimeout -Session $DiagramTempPssSession -ScriptBlock { Get-ADReplicationSubnet $using:Object }
                                 $SubnetArray += $SubnetName.Name
                             }
 
@@ -54,7 +54,7 @@ function Get-AbrADSitesInventoryInfo {
                         DomainControllers = & {
                             $DCsTable = @()
                             $DCsArray = @()
-                            $DCs = try { Get-ADObjectSearch -DN "CN=Servers,$($Site.DistinguishedName)" -Filter { objectClass -eq 'Server' } -Properties 'DNSHostName' -SelectPrty 'DNSHostName', 'Name' -Session $TempPssSession } catch { Out-Null }
+                            $DCs = try { Get-ADObjectSearch -DN "CN=Servers,$($Site.DistinguishedName)" -Filter { objectClass -eq 'Server' } -Properties 'DNSHostName' -SelectPrty 'DNSHostName', 'Name' -Session $DiagramTempPssSession } catch { Out-Null }
                             foreach ($Object in $DCs) {
                                 $DCsArray += $Object.DNSHostName
                             }

--- a/Src/Private/Get-AbrADTrust.ps1
+++ b/Src/Private/Get-AbrADTrust.ps1
@@ -108,15 +108,15 @@ function Get-AbrADTrust {
                             if ($Options.EnableDiagrams) {
                                 try {
                                     try {
-                                        $Graph = Get-AbrDiagrammer -DiagramType 'Trusts' -DiagramOutput base64 -DomainController $ValidDCFromDomain -PSSessionObject $TempPssSession
+                                        $Graph = Get-AbrDiagrammer -DiagramType 'Trusts' -DiagramOutput base64 -DomainController $ValidDCFromDomain
                                     } catch {
                                         Write-PScriboMessage -IsWarning -Message "Domain and Trusts Diagram Graph: $($_.Exception.Message)"
                                     }
 
                                     if ($Graph) {
-                                        if ((Get-DiaImagePercent -GraphObj $Graph).Width -gt 600) { $ImagePrty = 20 } else { $ImagePrty = 40 }
-                                        Section -Style Heading3 'Domain and Trusts Diagram.' {
-                                            Image -Base64 $Graph -Text 'Domain and Trusts Diagram' -Percent $ImagePrty -Align Center
+                                        $BestAspectRatio = Get-DiaBestImageAspectRatio -GraphObj $Graph -MaxWidth 600
+                                        Section -Style Heading3 'Domain and Trusts Diagram' {
+                                            Image -Base64 $Graph -Text 'Domain and Trusts Diagram' -Width $BestAspectRatio.Width -Height $BestAspectRatio.Height -Align Center
                                         }
                                         BlankLine -Count 2
                                     }

--- a/Src/Private/Get-AbrADTrustInfo.ps1
+++ b/Src/Private/Get-AbrADTrustInfo.ps1
@@ -54,7 +54,7 @@ function Get-AbrADTrustsInfo {
                 800 = 'Cross Organization (800)'
             }
 
-            $Trusts = Invoke-CommandWithTimeout -Session $TempPssSession -ScriptBlock { Get-ADTrust -Filter * -Properties CanonicalName, Target, TrustDirection, TrustAttributes, TrustType, SelectiveAuthentication } -ErrorAction Stop
+            $Trusts = Invoke-CommandWithTimeout -Session $DiagramTempPssSession -ScriptBlock { Get-ADTrust -Filter * -Properties CanonicalName, Target, TrustDirection, TrustAttributes, TrustType, SelectiveAuthentication } -ErrorAction Stop
 
             $TrustsInfo = @()
             if ($Trusts) {

--- a/Src/Private/Get-AbrDNSSection.ps1
+++ b/Src/Private/Get-AbrDNSSection.ps1
@@ -26,7 +26,7 @@ function Get-AbrDNSSection {
 
     process {
         if ($InfoLevel.DNS -ge 1) {
-            $DNSDomainObj = foreach ($Domain in $OrderedDomains) {
+            $DNSDomainObj = foreach ($Domain in ($OrderedDomains | Where-Object { $_ -notin $Options.Exclude.Domains })) {
                 if ($Domain -and ($Domain -notin $DomainStatus.Value.Name)) {
                     if (Get-ValidDCfromDomain -Domain $Domain -DCStatus ([ref]$DCStatus)) {
                         try {

--- a/Src/Private/Get-AbrDomainSection.ps1
+++ b/Src/Private/Get-AbrDomainSection.ps1
@@ -26,14 +26,13 @@ function Get-AbrDomainSection {
 
     process {
         if ($InfoLevel.Domain -ge 1) {
-            $DomainObj = foreach ($Domain in $OrderedDomains) {
+            $DomainObj = foreach ($Domain in ($OrderedDomains | Where-Object { $_ -notin $Options.Exclude.Domains })) {
                 if ($Domain -and ($Domain -notin $DomainStatus.Value.Name)) {
                     if ($ValidDC = Get-ValidDCfromDomain -Domain $Domain -DCStatus ([ref]$DCStatus)) {
                         # Define Filter option for Domain variable
                         try {
                             if ($DomainInfo = Invoke-CommandWithTimeout -Session $TempPssSession -ScriptBlock { Get-ADDomain -Identity $using:Domain }) {
                                 $DCs = Invoke-CommandWithTimeout -Session $TempPssSession -ScriptBlock { Get-ADDomain -Identity $using:Domain | Select-Object -ExpandProperty ReplicaDirectoryServers | Where-Object { $_ -notin ($using:Options).Exclude.DCs } } | Sort-Object
-
                                 Section -Style Heading2 "$($DomainInfo.DNSRoot.ToString().ToUpper())" {
                                     Paragraph 'This section provides a comprehensive overview of the Active Directory domain configuration, including key settings and critical details.'
                                     BlankLine

--- a/Src/Private/New-AbrADDiagram.ps1
+++ b/Src/Private/New-AbrADDiagram.ps1
@@ -494,12 +494,12 @@ function New-AbrADDiagram {
             try {
                 # Connection setup
                 if ($PSSessionObject) {
-                    $TempPssSession = $PSSessionObject
-                    $script:ADSystem = Invoke-CommandWithTimeout -Session $TempPssSession -ScriptBlock { Get-ADForest -ErrorAction Stop }
+                    $DiagramTempPssSession = $PSSessionObject
+                    $script:ADSystem = Invoke-CommandWithTimeout -Session $DiagramTempPssSession -ScriptBlock { Get-ADForest -ErrorAction Stop }
                 } else {
                     Write-Verbose ($reportTranslate.NewADDiagram.psSessionSetup -f $($System))
-                    $script:TempPssSession = New-PSSession $System -Credential $Credential -Authentication $PSDefaultAuthentication -ErrorAction Stop
-                    $script:ADSystem = Invoke-CommandWithTimeout -Session $TempPssSession -ScriptBlock { Get-ADForest -ErrorAction Stop }
+                    $script:DiagramTempPssSession = New-PSSession $System -Credential $Credential -Authentication $PSDefaultAuthentication -ErrorAction Stop
+                    $script:ADSystem = Invoke-CommandWithTimeout -Session $DiagramTempPssSession -ScriptBlock { Get-ADForest -ErrorAction Stop }
                 }
             } catch { throw ($reportTranslate.NewADDiagram.unableToConnect -f $System) }
 
@@ -581,8 +581,8 @@ function New-AbrADDiagram {
     } end {
         if (-not $PSSessionObject) {
             # Remove used PSSession
-            Write-Verbose ($reportTranslate.NewADDiagram.psSession -f $($TempPssSession.Id))
-            Remove-PSSession -Session $TempPssSession
+            Write-Verbose ($reportTranslate.NewADDiagram.psSession -f $($DiagramTempPssSession.Id))
+            Remove-PSSession -Session $DiagramTempPssSession
         }
 
         #Export Diagram


### PR DESCRIPTION
## [0.9.10] - 2026-01-26

### :arrows_clockwise: Changed

- Update module version to `0.9.10`
- Update Diagrammer.Core module to `0.2.37`

### :bug: Fixed

- Fix the computer/user stats table so that it displays the correct values
- Fix the size of the diagram, which does not respect the size of the document border
- Fix domain section not discovering information from root domain
- Fix the trust diagram, only displaying forest wide trust and not trusts from child domain