### PR TITLE
Fix DNS infrastructure to collect data from all domain controllers

### DIFF
--- a/Src/Private/Get-AbrADDNSInfrastructure.ps1
+++ b/Src/Private/Get-AbrADDNSInfrastructure.ps1
@@ -35,7 +35,8 @@ function Get-AbrADDNSInfrastructure {
                     foreach ($DC in $DCs) {
                         if (Get-DCWinRMState -ComputerName $DC -DCStatus ([ref]$DCStatus)) {
                             try {
-                                $DNSSetting = Get-DnsServerSetting -CimSession $TempCIMSession -ComputerName $DC
+                                $DCCimSession = Get-ValidCIMSession -ComputerName $DC -SessionName "$($DC)_DNS" -CIMTable ([ref]$CIMTable)
+                                $DNSSetting = Get-DnsServerSetting -CimSession $DCCimSession -ComputerName $DC
                                 $inObj = [ordered] @{
                                     'DC Name' = $($DC.ToString().ToUpper().Split('.')[0])
                                     'Build Number' = $DNSSetting.BuildNumber
@@ -73,7 +74,8 @@ function Get-AbrADDNSInfrastructure {
                                         try {
                                             Section -ExcludeFromTOC -Style NOTOCHeading5 $($DC.ToString().ToUpper().Split('.')[0]) {
                                                 $OutObj = [System.Collections.ArrayList]::new()
-                                                $DNSSetting = Get-DnsServerDirectoryPartition -CimSession $TempCIMSession -ComputerName $DC
+                                                $DCCimSession = Get-ValidCIMSession -ComputerName $DC -SessionName "$($DC)_DNS" -CIMTable ([ref]$CIMTable)
+                                                $DNSSetting = Get-DnsServerDirectoryPartition -CimSession $DCCimSession -ComputerName $DC
                                                 foreach ($Partition in $DNSSetting) {
                                                     try {
                                                         $inObj = [ordered] @{
@@ -124,7 +126,8 @@ function Get-AbrADDNSInfrastructure {
                                 foreach ($DC in $DCs) {
                                     if (Get-DCWinRMState -ComputerName $DC -DCStatus ([ref]$DCStatus)) {
                                         try {
-                                            $DNSSetting = Get-DnsServerResponseRateLimiting -CimSession $TempCIMSession -ComputerName $DC
+                                            $DCCimSession = Get-ValidCIMSession -ComputerName $DC -SessionName "$($DC)_DNS" -CIMTable ([ref]$CIMTable)
+                                            $DNSSetting = Get-DnsServerResponseRateLimiting -CimSession $DCCimSession -ComputerName $DC
                                             $inObj = [ordered] @{
                                                 'DC Name' = $($DC.ToString().ToUpper().Split('.')[0])
                                                 'Status' = $DNSSetting.Mode
@@ -166,7 +169,8 @@ function Get-AbrADDNSInfrastructure {
                                 foreach ($DC in $DCs) {
                                     if (Get-DCWinRMState -ComputerName $DC -DCStatus ([ref]$DCStatus)) {
                                         try {
-                                            $DNSSetting = Get-DnsServerScavenging -CimSession $TempCIMSession -ComputerName $DC
+                                            $DCCimSession = Get-ValidCIMSession -ComputerName $DC -SessionName "$($DC)_DNS" -CIMTable ([ref]$CIMTable)
+                                            $DNSSetting = Get-DnsServerScavenging -CimSession $DCCimSession -ComputerName $DC
                                             $inObj = [ordered] @{
                                                 'DC Name' = $($DC.ToString().ToUpper().Split('.')[0])
                                                 'NoRefresh Interval' = $DNSSetting.NoRefreshInterval
@@ -225,8 +229,9 @@ function Get-AbrADDNSInfrastructure {
                             foreach ($DC in $DCs) {
                                 if (Get-DCWinRMState -ComputerName $DC -DCStatus ([ref]$DCStatus)) {
                                     try {
-                                        $DNSSetting = Get-DnsServerForwarder -CimSession $TempCIMSession -ComputerName $DC
-                                        $Recursion = Get-DnsServerRecursion -CimSession $TempCIMSession -ComputerName $DC | Select-Object -ExpandProperty Enable
+                                        $DCCimSession = Get-ValidCIMSession -ComputerName $DC -SessionName "$($DC)_DNS" -CIMTable ([ref]$CIMTable)
+                                        $DNSSetting = Get-DnsServerForwarder -CimSession $DCCimSession -ComputerName $DC
+                                        $Recursion = Get-DnsServerRecursion -CimSession $DCCimSession -ComputerName $DC | Select-Object -ExpandProperty Enable
                                         $inObj = [ordered] @{
                                             'DC Name' = $($DC.ToString().ToUpper().Split('.')[0])
                                             'IP Address' = $DNSSetting.IPAddress.IPAddressToString
@@ -295,7 +300,8 @@ function Get-AbrADDNSInfrastructure {
                                         try {
                                             Section -ExcludeFromTOC -Style NOTOCHeading5 $($DC.ToString().ToUpper().Split('.')[0]) {
                                                 $OutObj = [System.Collections.ArrayList]::new()
-                                                $DNSSetting = Get-DnsServerRootHint -CimSession $TempCIMSession -ComputerName $DC -ErrorAction SilentlyContinue | Select-Object @{Name = 'Name'; E = { $_.NameServer.RecordData.Nameserver } }, @{ Name = 'IPv4Address'; E = { $_.IPAddress.RecordData.IPv4Address.IPAddressToString } }, @{ Name = 'IPv6Address'; E = { $_.IPAddress.RecordData.IPv6Address.IPAddressToString } }
+                                                $DCCimSession = Get-ValidCIMSession -ComputerName $DC -SessionName "$($DC)_DNS" -CIMTable ([ref]$CIMTable)
+                                                $DNSSetting = Get-DnsServerRootHint -CimSession $DCCimSession -ComputerName $DC -ErrorAction SilentlyContinue | Select-Object @{Name = 'Name'; E = { $_.NameServer.RecordData.Nameserver } }, @{ Name = 'IPv4Address'; E = { $_.IPAddress.RecordData.IPv4Address.IPAddressToString } }, @{ Name = 'IPv6Address'; E = { $_.IPAddress.RecordData.IPv6Address.IPAddressToString } }
                                                 if ($DNSSetting) {
                                                     foreach ($Hints in $DNSSetting) {
                                                         try {
@@ -396,7 +402,8 @@ function Get-AbrADDNSInfrastructure {
                                 foreach ($DC in $DCs) {
                                     if (Get-DCWinRMState -ComputerName $DC -DCStatus ([ref]$DCStatus)) {
                                         try {
-                                            $DNSSetting = Get-DnsServerRecursionScope -CimSession $TempCIMSession -ComputerName $DC
+                                            $DCCimSession = Get-ValidCIMSession -ComputerName $DC -SessionName "$($DC)_DNS" -CIMTable ([ref]$CIMTable)
+                                            $DNSSetting = Get-DnsServerRecursionScope -CimSession $DCCimSession -ComputerName $DC
                                             $inObj = [ordered] @{
                                                 'DC Name' = $($DC.ToString().ToUpper().Split('.')[0])
                                                 'Zone Name' = switch ($DNSSetting.Name) {


### PR DESCRIPTION
## Summary

- Replace shared `$TempCIMSession` with DC-specific CIM sessions via `Get-ValidCIMSession` in all DNS infrastructure sections

## Problem

`Get-AbrADDNSInfrastructure` iterates over all domain controllers in 7 DNS sections, but passes `$TempCIMSession` to every DNS cmdlet call. `$TempCIMSession` always points to the target DC specified with `-Target`, so all DNS data is collected from that single DC regardless of which `$DC` is being iterated.

This means DNS sections like Forwarder Options, Scavenging, Root Hints, etc. are all sourced from the target DC. The report only shows one DNS server and not listing all of them and does not list the Forwarder Options set on all the other DNS servers, which can vary.

## Fix

At each of the 7 locations where DNS cmdlets are called inside `foreach ($DC in $DCs)` loops, create a DC-specific CIM session:

```powershell
# Before (reuses target DC session for all DCs):
$DNSSetting = Get-DnsServerForwarder -CimSession $TempCIMSession -ComputerName $DC

# After (creates DC-specific session):
$DCCimSession = Get-ValidCIMSession -ComputerName $DC -SessionName "$($DC)_DNS" -CIMTable ([ref]$CIMTable)
$DNSSetting = Get-DnsServerForwarder -CimSession $DCCimSession -ComputerName $DC
```

**Sections fixed:**
- Infrastructure Summary (`Get-DnsServerSetting`)
- Application Directory Partition (`Get-DnsServerDirectoryPartition`)
- Response Rate Limiting (`Get-DnsServerResponseRateLimiting`)
- Scavenging Options (`Get-DnsServerScavenging`)
- Forwarder Options (`Get-DnsServerForwarder`, `Get-DnsServerRecursion`)
- Root Hints (`Get-DnsServerRootHint`)
- Zone Scope Recursion (`Get-DnsServerRecursionScope`)

## Test Plan

- [x] Tested against a 5-DC Active Directory environment (4 DCs with WinRM enabled)
- [x] DCs spanning Azure East US, Azure West US, and China Azure regions
- [x] All DNS sections now correctly display per-DC configuration data
- [x] Infrastructure Summary shows all 4 accessible DCs with unique settings
- [x] Forwarder Options shows DNS forwarder configuration from each DC individually