### PR TITLE
v1.0.1

### DIFF
--- a/AsBuiltReport.Microsoft.AD/AsBuiltReport.Microsoft.AD.psd1
+++ b/AsBuiltReport.Microsoft.AD/AsBuiltReport.Microsoft.AD.psd1
@@ -54,15 +54,15 @@
     RequiredModules = @(
         @{
             ModuleName = 'AsBuiltReport.Core';
-            ModuleVersion = '1.6.3'
+            ModuleVersion = '1.6.4'
         },
         @{
             ModuleName = 'AsBuiltReport.Chart';
-            ModuleVersion = '0.3.2'
+            ModuleVersion = '0.3.3'
         },
         @{
             ModuleName = 'AsBuiltReport.Diagram';
-            ModuleVersion = '1.0.7'
+            ModuleVersion = '1.0.8'
         }
     )
 

--- a/AsBuiltReport.Microsoft.AD/Language/en-US/MicrosoftAD.psd1
+++ b/AsBuiltReport.Microsoft.AD/Language/en-US/MicrosoftAD.psd1
@@ -42,7 +42,7 @@
     DomainControllers = Domain Controllers
     Domains = Domains
     NoData = No data returned (Get-ADForest returned $null)
-'@
+    RunAsAdministrator = Please run the report with Run As Administrator priviledges.
 
     # InvokeAsBuiltReportMicrosoftAD
     ConvertToTextYN = ConvertFrom-StringData @'

--- a/AsBuiltReport.Microsoft.AD/Language/es-ES/MicrosoftAD.psd1
+++ b/AsBuiltReport.Microsoft.AD/Language/es-ES/MicrosoftAD.psd1
@@ -42,6 +42,7 @@
     DomainControllers = Controladores de Dominio
     Domains = Dominios
     NoData = No hay datos disponibles (Get-ADForest devolvió $null)
+    RunAsAdministrator = Please run the report with Run As Administrator priviledges.
 '@
 
     # ConvertToTextYN

--- a/AsBuiltReport.Microsoft.AD/Src/Private/Gui/Start-AsBuiltReportMSAD.ps1
+++ b/AsBuiltReport.Microsoft.AD/Src/Private/Gui/Start-AsBuiltReportMSAD.ps1
@@ -1,5 +1,3 @@
-#Requires -RunAsAdministrator
-
 using namespace GliderUI
 using namespace GliderUI.Avalonia
 using namespace GliderUI.Avalonia.Controls
@@ -30,6 +28,13 @@ function Start-AsBuiltReportMSAD {
 
     if ($PSVersionTable.PSVersion.Major -lt 7 -or ($PSVersionTable.PSVersion.Major -eq 7 -and $PSVersionTable.PSVersion.Minor -lt 4)) {
         throw "Start-AsBuiltReportMSAD requires PowerShell 7.4+. Current version: $($PSVersionTable.PSVersion)"
+    }
+
+    $IsAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+    if (-not $IsAdmin) {
+        Write-Error -Message 'Please run the report with Run As Administrator priviledges.'
+        break
     }
 
     # ── Bootstrap GliderUI ──────────────────────────────────────────────────────

--- a/AsBuiltReport.Microsoft.AD/Src/Public/Invoke-AsBuiltReport.Microsoft.AD.ps1
+++ b/AsBuiltReport.Microsoft.AD/Src/Public/Invoke-AsBuiltReport.Microsoft.AD.ps1
@@ -5,7 +5,7 @@ function Invoke-AsBuiltReport.Microsoft.AD {
     .DESCRIPTION
         Documents the configuration of Microsoft AD in Word/HTML/Text formats using PScribo.
     .NOTES
-        Version:        1.0.0
+        Version:        1.0.1
         Author:         Jonathan Colon
         Twitter:        @jcolonfzenpr
         Github:         rebelinux
@@ -22,8 +22,14 @@ function Invoke-AsBuiltReport.Microsoft.AD {
         [PSCredential] $Credential
     )
 
-    #Requires -RunAsAdministrator
     #Requires -Version 7.4
+
+    $IsAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+    if (-not $IsAdmin) {
+        Write-Error -Message $reportTranslate.InvokeAsBuiltReportMicrosoftAD.RunAsAdministrator
+        break
+    }
 
     if ($psISE) {
         Write-Error -Message $reportTranslate.InvokeAsBuiltReportMicrosoftAD.PwshISE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add cmdlet Get-AbrAdLog to collect report diagnostic log
+- Add cmdlet `Get-AbrAdLog` to collect report diagnostic log
+
+### Changed
+
+- Bump module version to `1.0.1`
+- Upgrade AsBuiltReport.Diagram module to version `1.0.8`
+- Upgrade AsBuiltReport.Chart module to version `0.3.3`
 
 ### Fixed
 
 - Add validation for ADSystem before accessing RootDomain to prevent errors
-- Add success message logging for completed commands in Invoke-CommandWithTimeout function
+- Add success message logging for completed commands in `Invoke-CommandWithTimeout` function
 - Update localization files to include NoData messages and improve key matching in tests
+- Fix [255](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/255)
 
 ## [1.0.0] - 2026-05-02
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ A Microsoft AD As Built Report can be generated with Active Directory Enterprise
 Due to a limitation of the WinRM component, a domain-joined machine is needed, also it is required to use the FQDN of the DC instead of it's IP address.
 [Reference](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_remote_troubleshooting?view=powershell-7.1#how-to-use-an-ip-address-in-a-remote-command)
 
+- The report must be run in a console with administrator privileges (“Run as Administrator”).
+
 ## :package: Module Installation
 
 ### PowerShell v5.x running on a Domain Controller server

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ A Microsoft AD As Built Report can be generated with Active Directory Enterprise
 Due to a limitation of the WinRM component, a domain-joined machine is needed, also it is required to use the FQDN of the DC instead of it's IP address.
 [Reference](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_remote_troubleshooting?view=powershell-7.1#how-to-use-an-ip-address-in-a-remote-command)
 
-- The report must be run in a console with administrator privileges (“Run as Administrator”).
+> [!WARNING]
+> The report must be run in a console with administrator privileges (“Run as Administrator”).
 
 ## :package: Module Installation
 


### PR DESCRIPTION
## [1.0.1] - unreleased

### Added

- Add cmdlet `Get-AbrAdLog` to collect report diagnostic log

### Changed

- Bump module version to `1.0.1`
- Upgrade AsBuiltReport.Diagram module to version `1.0.8`
- Upgrade AsBuiltReport.Chart module to version `0.3.3`

### Fixed

- Add validation for ADSystem before accessing RootDomain to prevent errors
- Add success message logging for completed commands in `Invoke-CommandWithTimeout` function
- Update localization files to include NoData messages and improve key matching in tests
- Fix [255](https://github.com/AsBuiltReport/AsBuiltReport.Microsoft.AD/issues/255)