### PR TITLE
v1.0.3 public release

### DIFF
--- a/AsBuiltReport.Microsoft.AD/AsBuiltReport.Microsoft.AD.psd1
+++ b/AsBuiltReport.Microsoft.AD/AsBuiltReport.Microsoft.AD.psd1
@@ -12,7 +12,7 @@
     RootModule = 'AsBuiltReport.Microsoft.AD.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.0.2'
+    ModuleVersion = '1.0.3'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core')
@@ -62,7 +62,7 @@
         },
         @{
             ModuleName = 'AsBuiltReport.Diagram';
-            ModuleVersion = '1.0.8'
+            ModuleVersion = '1.0.10'
         }
     )
 

--- a/AsBuiltReport.Microsoft.AD/Src/Private/Diagram/New-AbrADDiagram.ps1
+++ b/AsBuiltReport.Microsoft.AD/Src/Private/Diagram/New-AbrADDiagram.ps1
@@ -572,7 +572,7 @@ function New-AbrADDiagram {
         #Export Diagram
         foreach ($OutputFormat in $Format) {
 
-            $OutputDiagram = Export-AbrDiagram -GraphObj ($Graph | Select-String -Pattern '"([A-Z])\w+"\s\[label="";style="invis";shape="point";]' -NotMatch) -ErrorDebug $EnableErrorDebug -Format $OutputFormat -Filename $Filename -OutputFolderPath $OutputFolderPath -WaterMarkText $WaterMarkText -WaterMarkColor $WaterMarkColor -IconPath $IconPath -Verbose:$Verbose -Rotate $Rotate
+            $OutputDiagram = Export-AbrDiagram -GraphObj ($Graph | Select-String -Pattern '(?s)"?\w+"?\s+\[\s*label="";\s*shape="point";\s*style="invis";\s*\]' -NotMatch) -ErrorDebug $EnableErrorDebug -Format $OutputFormat -Filename $Filename -OutputFolderPath $OutputFolderPath -WaterMarkText $WaterMarkText -WaterMarkColor $WaterMarkColor -IconPath $IconPath -Verbose:$Verbose -Rotate $Rotate
 
             if ($OutputDiagram) {
                 if ($OutputFormat -ne 'Base64') {

--- a/AsBuiltReport.Microsoft.AD/Src/Private/Diagram/New-AbrADDiagram.ps1
+++ b/AsBuiltReport.Microsoft.AD/Src/Private/Diagram/New-AbrADDiagram.ps1
@@ -533,29 +533,30 @@ function New-AbrADDiagram {
 
                         # Call Forest Diagram
                         if ($DiagramType -eq 'Forest') {
-                            if ($ForestInfo = Get-AbrDiagForest | Select-String -Pattern '"([A-Z])\w+"\s\[label="";style="invis";shape="point";]' -NotMatch) {
+                            if ($ForestInfo = Get-AbrDiagForest) {
                                 $ForestInfo
                             } else { Write-Warning $reportTranslate.NewADDiagram.emptyForest }
                         } elseif ($DiagramType -eq 'CertificateAuthority') {
                             $CAInfo = Get-AbrDiagCertificateAuthority
-                            if ($CAInfo = Get-AbrDiagCertificateAuthority | Select-String -Pattern '"([A-Z])\w+"\s\[label="";style="invis";shape="point";]' -NotMatch) {
+                            if ($CAInfo = Get-AbrDiagCertificateAuthority) {
                                 $CAInfo
                             } else { Write-Warning $reportTranslate.NewADDiagram.emptyForest }
                         } elseif ($DiagramType -eq 'Sites') {
-                            if ($SitesInfo = Get-AbrDiagSite | Select-String -Pattern '"([A-Z])\w+"\s\[label="";style="invis";shape="point";]' -NotMatch) {
+                            if ($SitesInfo = Get-AbrDiagSite) {
                                 $SitesInfo
                             } else { Write-Warning $reportTranslate.NewADDiagram.emptySites }
                         } elseif ($DiagramType -eq 'SitesInventory') {
-                            if ($SitesInfo = Get-AbrDiagSiteInventory | Select-String -Pattern '"([A-Z])\w+"\s\[label="";style="invis";shape="point";]' -NotMatch) {
+                            if ($SitesInfo = Get-AbrDiagSiteInventory) {
                                 $SitesInfo
                             } else { Write-Warning $reportTranslate.NewADDiagram.emptySites }
                         } elseif ($DiagramType -eq 'Trusts') {
-                            if ($TrustsInfo = Get-AbrDiagTrust | Select-String -Pattern '"([A-Z])\w+"\s\[label="";style="invis";shape="point";]' -NotMatch) {
+                            if ($TrustsInfo = Get-AbrDiagTrust) {
                                 $TrustsInfo
                             } else { Write-Warning $reportTranslate.NewADDiagram.emptyTrusts }
                         } elseif ($DiagramType -eq 'Replication') {
-                            if ($ReplInfo = Get-AbrDiagReplication | Select-String -Pattern '"([A-Z])\w+"\s\[label="";style="invis";shape="point";]' -NotMatch) {
+                            if ($ReplInfo = Get-AbrDiagReplication) {
                                 $ReplInfo
+                                $ReplInfo | Out-File ./Data.txt
                             } else { Write-Warning $reportTranslate.NewADDiagram.emptyReplication }
                         }
                     }
@@ -572,7 +573,9 @@ function New-AbrADDiagram {
         #Export Diagram
         foreach ($OutputFormat in $Format) {
 
-            $OutputDiagram = Export-AbrDiagram -GraphObj ($Graph | Select-String -Pattern '(?s)"?\w+"?\s+\[\s*label="";\s*shape="point";\s*style="invis";\s*\]' -NotMatch) -ErrorDebug $EnableErrorDebug -Format $OutputFormat -Filename $Filename -OutputFolderPath $OutputFolderPath -WaterMarkText $WaterMarkText -WaterMarkColor $WaterMarkColor -IconPath $IconPath -Verbose:$Verbose -Rotate $Rotate
+            $filterPattern = $Graph | Select-String -Pattern '(?s)"?\w+"?\s+\[\s*label="";\s*shape="point";\s*style="invis";\s*\]', '(?s)"?\w+"?\s+\[\s*label="";\s*style="invis";\s*shape="point";\s*\]', '(?s)"?\w+"?\s+\[\s*shape="point";\s*label="";\s*style="invis";\s*\]', '(?s)"?\w+"?\s+\[\s*shape="point";\s*style="invis";\s*label="";\s*\]', '(?s)"?\w+"?\s+\[\s*style="invis";\s*label="";\s*shape="point";\s*\]', '(?s)"?\w+"?\s+\[\s*style="invis";\s*shape="point";\s*label="";\s*\]' -NotMatch
+
+            $OutputDiagram = Export-AbrDiagram -GraphObj $filterPattern -ErrorDebug $EnableErrorDebug -Format $OutputFormat -Filename $Filename -OutputFolderPath $OutputFolderPath -WaterMarkText $WaterMarkText -WaterMarkColor $WaterMarkColor -IconPath $IconPath -Verbose:$Verbose -Rotate $Rotate
 
             if ($OutputDiagram) {
                 if ($OutputFormat -ne 'Base64') {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ##### This project is community maintained and has no sponsorship from Microsoft, its employees or any of its affiliates.
 
+## [1.0.2] - 2026-08-02
+
+### Changed
+
+- Bump module version to `1.0.3`
+- Upgrade AsBuiltReport.Diagram module to version `1.0.10`
+
+### Fixed
+
+- Fix for hidden nodes in diagrams not being filtered out correctly, which could lead to incomplete or inaccurate visual representations of the Active Directory structure in the generated reports.
+
 ## [1.0.2] - 2026-07-27
 
 ### Changed


### PR DESCRIPTION
## [1.0.3] - 2026-09-14

### Changed

- Bump module version to `1.0.3`
- Upgrade AsBuiltReport.Diagram module to version `1.0.11`

### Fixed

- Fix for hidden nodes in diagrams not being filtered out correctly, which could lead to incomplete or inaccurate visual representations of the Active Directory structure in the generated reports.
